### PR TITLE
Improve AI move & switch heuristics; add tests

### DIFF
--- a/sim/tools/player-ai.ts
+++ b/sim/tools/player-ai.ts
@@ -97,6 +97,7 @@ export class PlayerAI extends BattlePlayer {
 			disabledMovesByMon: new Map(),
 			trappedActiveByMon: new Set(),
 			lastSwitchTurnByMon: new Map(),
+			lastMoveFailedByMon: new Set(),
 			noiseEpsilon: 0,
 			infoForgetting: 0,
 			searchBudgetMs: options.searchBudgetMs,

--- a/sim/tools/strategic-ai/engines/Engine.ts
+++ b/sim/tools/strategic-ai/engines/Engine.ts
@@ -39,6 +39,15 @@ export interface EngineContext {
 	/** Per-Pokemon disabled-move sets (Imprison/Disable). */
 	disabledMovesByMon: Map<string, Set<string>>;
 	/**
+	 * Per-Pokemon "did the previous move attempt fail" flag, set by
+	 * {@link PlayerAI.receiveLine} when a `|miss|`, `|-immune|`, or
+	 * `|cant|` line is parsed against that mon. Cleared the next time
+	 * the same mon successfully uses a move. Used by power-doubling
+	 * moves like Stomping Tantrum (2× BP when the user's previous move
+	 * failed).
+	 */
+	lastMoveFailedByMon: Set<string>;
+	/**
 	 * Per-Pokemon "is trapped" override fed by error feedback (see
 	 * `PlayerAI.receiveError`). The simulator only sets `request.active[i]
 	 * .trapped = true` when it's been told the foe revealed a trapping

--- a/sim/tools/strategic-ai/engines/HeuristicEngine.ts
+++ b/sim/tools/strategic-ai/engines/HeuristicEngine.ts
@@ -31,7 +31,7 @@ import type {
 } from "../../../side";
 import { calculateDamage, fromTracked } from "../mechanics/DamageCalc";
 import { evaluateMove, type MoveEvalContext } from "../mechanics/MoveEvaluator";
-import { chooseBestSwitch, evaluateMatchup } from "../mechanics/SwitchEvaluator";
+import { chooseBestSwitch, evaluateMatchup, scaledSpeed } from "../mechanics/SwitchEvaluator";
 import { pickTarget } from "../mechanics/TargetPicker";
 import { chooseTransform } from "../mechanics/TransformPolicy";
 import type { BattleStateTracker, TrackedPokemon } from "../state/BattleStateTracker";
@@ -237,7 +237,7 @@ export class HeuristicEngine implements Engine {
 		const trapped = !!active.trapped || erroredTrapped;
 		if (!trapped && switchCandidates.length > 0) {
 			const switchDecision = this.maybeSwitchOut(
-				myMon, foeMon, tracker, side, slotIndex, ctx, switchCandidates
+				myMon, foeMon, tracker, side, slotIndex, ctx, switchCandidates, active
 			);
 			if (switchDecision) {
 				if (monId) ctx.lastSwitchTurnByMon.set(monId, tracker.turn);
@@ -270,6 +270,10 @@ export class HeuristicEngine implements Engine {
 			valueOfBestSwitch: switchCandidates.length ?
 				this.bestSwitchValue(switchCandidates, foeMon, tracker) :
 				0,
+			// Plumb "did our last attempt fizzle?" through to the move
+			// scorer. This lets Stomping Tantrum's 2× BP fire after
+			// e.g. an Earthquake into Levitate the previous turn.
+			attackerLastMoveFailed: myMon.lastMoveFailed,
 		};
 
 		const scored = this.scoreCandidates(availableMoves, evalCtx, ctx);
@@ -306,7 +310,8 @@ export class HeuristicEngine implements Engine {
 		side: SideRequestData,
 		slotIndex: number,
 		ctx: EngineContext,
-		switchCandidates: { req: PokemonSwitchRequestData, idx: number, mon: TrackedPokemon }[]
+		switchCandidates: { req: PokemonSwitchRequestData, idx: number, mon: TrackedPokemon }[],
+		active: PokemonMoveRequestData
 	): string | null {
 		const monId = this.monIdForSlot(side, slotIndex, ctx);
 		const lastSwitch = monId ? ctx.lastSwitchTurnByMon.get(monId) : undefined;
@@ -315,8 +320,17 @@ export class HeuristicEngine implements Engine {
 		const myHp = myMon.hpFraction ?? 1;
 		const matchup = evaluateMatchup(myMon, foeMon, tracker);
 		const myStats = myMon.stats;
-		const foeStats = foeMon.stats;
-		const wereFaster = (myStats?.spe ?? 0) > (foeStats?.spe ?? 0);
+		// Use `scaledSpeed` (weather doubled / Tailwind / boosts / status)
+		// so emergency / dominant-outspeeder checks match the matchup
+		// scorer. Without this, a Swift Swim user in rain reads as
+		// "slower" for emergency logic but "faster" for matchup logic
+		// — exactly the bug behind the Mega-Sceptile vs Pelipper /
+		// Barraskewda misfire reported in playtest.
+		const myTailwind = tracker.sides[tracker.mySide].tailwindTurns > 0;
+		const foeTailwind = tracker.sides[tracker.foeSide].tailwindTurns > 0;
+		const myEff = scaledSpeed(myMon, myTailwind, tracker.field.weather);
+		const foeEff = scaledSpeed(foeMon, foeTailwind, tracker.field.weather);
+		const wereFaster = tracker.field.trickRoom ? myEff < foeEff : myEff > foeEff;
 
 		// Find best candidate so we can both rank it and use it for the
 		// proactive-synergy trigger below.
@@ -341,17 +355,41 @@ export class HeuristicEngine implements Engine {
 			bestScore - matchup.score >= PROACTIVE_SWITCH_DELTA &&
 			proactiveSurvives;
 
+		const emergencySwitch =
+			(myHp < FAINT_THRESHOLD && !wereFaster) ||
+			((myMon.boosts.atk || 0) <= -3 && (myStats?.atk ?? 0) >= (myStats?.spa ?? 0)) ||
+			((myMon.boosts.spa || 0) <= -3 && (myStats?.spa ?? 0) >= (myStats?.atk ?? 0));
+
 		// "Don't waste a consumed-item activation": if the current mon
 		// is sitting on a fresh boost it paid for (Paradox boost from
 		// Booster Energy / matching weather/terrain, terrain-seed Def/
 		// SpD bump, Flash Fire / Charge, etc.) leaving it costs a real
 		// resource. Refuse non-emergency switches in that state.
-		const activatedBoostUp = hasActiveConsumableBoost(myMon, tracker);
-		const emergencySwitch =
-			(myHp < FAINT_THRESHOLD && !wereFaster) ||
-			((myMon.boosts.atk || 0) <= -3 && (myStats?.atk ?? 0) >= (myStats?.spa ?? 0)) ||
-			((myMon.boosts.spa || 0) <= -3 && (myStats?.spa ?? 0) >= (myStats?.atk ?? 0));
-		if (activatedBoostUp && !emergencySwitch) return null;
+		if (hasActiveConsumableBoost(myMon, tracker) && !emergencySwitch) return null;
+
+		// Setup-window preservation: a fresh Focus Sash / Sturdy mon
+		// at full HP is locked in to one more turn no matter how scary
+		// the matchup looks; pivoting away wastes the protection. Same
+		// logic for Weakness Policy when the foe's revealed kit
+		// includes a SE attack (the WP will fire, we get +2/+2).
+		if (shouldPreserveSetupWindow(myMon, foeMon) && !emergencySwitch) return null;
+
+		// Already-dominant: if we outspeed AND can already pressure the
+		// foe meaningfully (>= 25% per swing) AND we're not low HP,
+		// proactive switching just throws tempo away. The user's
+		// playtests showed flip-flop swaps from healthy outspeeding
+		// mons; this guard closes that branch.
+		const weDealMeaningful = matchup.weDealFraction >= 0.25;
+		if (wereFaster && weDealMeaningful && myHp >= 0.5 && matchup.score >= 0) return null;
+
+		// "We can clean up with priority next turn": refuse to swap into
+		// a healthy teammate (almost always a sacrifice setup) when our
+		// current mon has a usable priority move that would KO the foe.
+		// Even if the matchup score says "you're losing", the actual
+		// outcome is "we KO before they move" → we don't need a swap.
+		if (this.hasUsablePriorityKO(myMon, foeMon, tracker, active, ctx) && !emergencySwitch) {
+			return null;
+		}
 
 		const wantSwitch =
 			emergencySwitch ||
@@ -370,6 +408,24 @@ export class HeuristicEngine implements Engine {
 		// foe gets a free turn either way).
 		const candidateSurvives = best.score.foeDealFraction + best.score.hazardFraction < 0.95;
 		const isEmergency = myHp < FAINT_THRESHOLD && !wereFaster;
+		// Stay-and-sac gate: when the *current* mon is already going to
+		// faint to the foe's best plausible attack this turn (foe is
+		// faster and OHKOs us, or we're a doomed Sash/Sturdy) AND the
+		// best switch-in would also eat heavy chip on entry, staying
+		// is the correct play — we get one more attack / hazard / status
+		// for free instead of throwing a fresh mon into the same shot.
+		//
+		// The textbook scenario is the Mega-Sceptile (+2 SD) vs Pelipper
+		// (Drizzle) / Barraskewda (Swift Swim) line: Pelipper is dead
+		// either way, and pivoting Barraskewda in straight into Leaf
+		// Storm wastes the cleaner. Sac Pelipper, send Barraskewda on
+		// a free turn.
+		const wereDying = !wereFaster &&
+			matchup.foeDealFraction >= 0.9 &&
+			!hasGuaranteedSurvivalForActive(myMon);
+		const candidateAlsoChipped =
+			best.score.foeDealFraction + best.score.hazardFraction >= 0.7;
+		if (wereDying && candidateAlsoChipped && !emergencySwitch) return null;
 		if (!candidateSurvives && !isEmergency) return null;
 		const slot = switchCandidates.find(c => c.mon.id === best.mon.id);
 		if (!slot) return null;
@@ -377,6 +433,46 @@ export class HeuristicEngine implements Engine {
 		const skill = Math.max(0, Math.min(1, (ctx.difficulty - 1) / 4));
 		if (ctx.prng.random() > skill) return null;
 		return `switch ${slot.idx}`;
+	}
+
+	/**
+	 * True iff the active mon has a usable (PP > 0, not disabled,
+	 * non-status) positive-priority move that has a high probability of
+	 * KOing the current foe on the next turn. Used by the switch-out
+	 * gate to refuse pivots when we're already a one-turn-KO threat.
+	 *
+	 * @param myMon Tracked current mon.
+	 * @param foeMon Tracked foe active.
+	 * @param tracker Battle state tracker.
+	 * @param active Request payload for the active slot (move PP/lock).
+	 * @param ctx Engine context (for per-mon disabled-move set).
+	 * @returns true when at least one priority move probably KOs.
+	 */
+	private hasUsablePriorityKO(
+		myMon: TrackedPokemon,
+		foeMon: TrackedPokemon,
+		tracker: BattleStateTracker,
+		active: PokemonMoveRequestData,
+		ctx: EngineContext
+	): boolean {
+		const monDisabled = ctx.disabledMovesByMon.get(myMon.id);
+		for (const m of active.moves) {
+			if (m.disabled || m.pp === 0) continue;
+			if (monDisabled?.has(m.id)) continue;
+			const move = moveOf(m.id);
+			if (!move?.exists || move.category === "Status") continue;
+			if ((move.priority ?? 0) <= 0) continue;
+			const calc = calculateDamage({
+				attacker: fromTracked(myMon),
+				defender: fromTracked(foeMon),
+				move,
+				field: tracker.field,
+				attackerSide: tracker.sides[tracker.mySide],
+				defenderSide: tracker.sides[tracker.foeSide],
+			});
+			if (calc.koProbability > 0.6) return true;
+		}
+		return false;
 	}
 
 	/**
@@ -633,6 +729,90 @@ function hasActiveConsumableBoost(
 		return true;
 	}
 	return false;
+}
+
+/**
+ * True when the current mon is sitting on a setup-window resource that
+ * a switch-out would waste. We're conservative on purpose: only flag
+ * cases where the resource is *about* to pay off this very turn, so
+ * the engine doesn't lock itself into a doomed mon just because it
+ * holds a Sash.
+ *
+ * Covered cases:
+ *
+ * - **Focus Sash at full HP**: guaranteed survival of any one hit;
+ *   pivoting away throws that protection (the Sash is on, the swap-in
+ *   doesn't inherit it).
+ * - **Sturdy at full HP**: same guarantee, ability-based.
+ * - **Weak Armor / Anger Point** with the foe likely to fire a SE /
+ *   physical hit and us surviving — the trigger arrives next turn,
+ *   pre-empt the swap.
+ * - **Weakness Policy holder** when the foe has revealed a SE move
+ *   AND we can survive that hit (matchup `foeDealFraction < 0.9` is a
+ *   rough proxy for "Sash/Sturdy/multiscale/Eviolite let us tank").
+ * - **Unburden holder** carrying a one-shot consumable (Sash, Berry,
+ *   Seed, Booster) — about to lose the item and double its speed.
+ *
+ * @param myMon Tracked current mon.
+ * @param foeMon Tracked foe active.
+ * @returns true when a swap would burn the setup window.
+ */
+function shouldPreserveSetupWindow(
+	myMon: TrackedPokemon,
+	foeMon: TrackedPokemon
+): boolean {
+	const hpf = myMon.hpFraction ?? 1;
+	const item = toID(myMon.item);
+	const ability = toID(myMon.ability);
+	if (hpf >= 0.99 && item === "focussash") return true;
+	if (hpf >= 0.99 && ability === "sturdy") return true;
+	// Weakness Policy: only relevant if the foe has actually revealed
+	// a SE move (anything else is speculation), and we plausibly tank
+	// at least one such hit (no need for full survivability math here
+	// — the broader survivability gate in `evaluateMatchup` handles
+	// the OHKO case via the score the caller already consulted).
+	if (item === "weaknesspolicy" && hpf >= 0.6) {
+		for (const moveId of foeMon.revealedMoves) {
+			const move = Dex.moves.get(moveId);
+			if (!move?.exists || move.category === "Status") continue;
+			let eff = 0;
+			for (const t of myMon.types) eff += Dex.getEffectiveness(move.type, t);
+			if (eff > 0) return true;
+		}
+	}
+	// Unburden: holding a one-shot consumable that's about to fire.
+	// Pivoting away forfeits both the consumable's effect *and* the
+	// post-consume +Speed.
+	if (ability === "unburden") {
+		const oneShotItems = new Set([
+			"focussash", "boosterenergy",
+			"grassyseed", "electricseed", "mistyseed", "psychicseed",
+			"salacberry", "liechiberry", "petayaberry",
+			"ganlonberry", "apicotberry", "starfberry",
+			"sitrusberry", "lumberry",
+		]);
+		if (oneShotItems.has(item)) return true;
+	}
+	return false;
+}
+
+/**
+ * True iff the given active mon has a one-shot "live through anything"
+ * guarantee this turn — Focus Sash at full HP or Sturdy at full HP.
+ * Used by the stay-and-sac gate: a doomed mon is exempt when it still
+ * has a survival guarantee, since that guarantee will pay for our
+ * "one more turn" play anyway.
+ *
+ * @param mon The current active mon to inspect.
+ * @returns true when the mon should be considered "guaranteed to
+ *   survive this turn no matter what hits it".
+ */
+function hasGuaranteedSurvivalForActive(mon: TrackedPokemon): boolean {
+	const hpf = mon.hpFraction ?? 1;
+	if (hpf < 0.99) return false;
+	const item = toID(mon.item);
+	const ability = toID(mon.ability);
+	return item === "focussash" || ability === "sturdy";
 }
 
 /** Re-export the small helper consumers may want. */

--- a/sim/tools/strategic-ai/engines/HeuristicEngine.ts
+++ b/sim/tools/strategic-ai/engines/HeuristicEngine.ts
@@ -57,6 +57,18 @@ const SWITCH_OUT_MATCHUP = -8;
 const PROACTIVE_SWITCH_DELTA = 18;
 /** Absolute bench score required to take a proactive switch. */
 const PROACTIVE_SWITCH_FLOOR = 12;
+/**
+ * Moves whose positive priority (or usability) is conditional and so
+ * can't be relied on to KO on a future turn: Fake Out / First Impression
+ * only work on the switch-in turn, Sucker Punch only fires if the foe
+ * attacks. They must not count toward the "we're already a priority-KO
+ * threat, don't switch out" veto.
+ */
+const CONDITIONAL_PRIORITY_MOVES = new Set([
+	"fakeout",
+	"firstimpression",
+	"suckerpunch",
+]);
 
 /** Lazy `Dex.moves.get`. */
 function moveOf(id: string) {
@@ -328,8 +340,8 @@ export class HeuristicEngine implements Engine {
 		// Barraskewda misfire reported in playtest.
 		const myTailwind = tracker.sides[tracker.mySide].tailwindTurns > 0;
 		const foeTailwind = tracker.sides[tracker.foeSide].tailwindTurns > 0;
-		const myEff = scaledSpeed(myMon, myTailwind, tracker.field.weather);
-		const foeEff = scaledSpeed(foeMon, foeTailwind, tracker.field.weather);
+		const myEff = scaledSpeed(myMon, myTailwind, tracker.field.weather, tracker.field.terrain);
+		const foeEff = scaledSpeed(foeMon, foeTailwind, tracker.field.weather, tracker.field.terrain);
 		const wereFaster = tracker.field.trickRoom ? myEff < foeEff : myEff > foeEff;
 
 		// Find best candidate so we can both rank it and use it for the
@@ -462,6 +474,12 @@ export class HeuristicEngine implements Engine {
 			const move = moveOf(m.id);
 			if (!move?.exists || move.category === "Status") continue;
 			if ((move.priority ?? 0) <= 0) continue;
+			// Conditional-priority moves only have their priority (and
+			// sometimes only work at all) under specific circumstances:
+			// Fake Out / First Impression only on the turn we switch in,
+			// Sucker Punch only if the foe attacks. We can't rely on
+			// them to KO "next turn", so they must not veto a switch.
+			if (CONDITIONAL_PRIORITY_MOVES.has(toID(m.id))) continue;
 			const calc = calculateDamage({
 				attacker: fromTracked(myMon),
 				defender: fromTracked(foeMon),

--- a/sim/tools/strategic-ai/engines/HeuristicEngine.ts
+++ b/sim/tools/strategic-ai/engines/HeuristicEngine.ts
@@ -47,6 +47,16 @@ const SWITCH_LOCK_TURNS = 2;
 const PROTECT_CONSIDER_CHANCE = 0.15;
 /** Switch-out matchup threshold; below this, switching is favoured. */
 const SWITCH_OUT_MATCHUP = -8;
+/**
+ * Proactive-switch trigger: switch out even from a non-bad matchup if a
+ * bench mon outscores the current one by at least this much. Sized so
+ * the AI doesn't flip-flop on small numerical edges, but does take
+ * obvious synergies (e.g. Grassy Seed in Grassy Terrain, 4× resist on
+ * the bench) when they appear.
+ */
+const PROACTIVE_SWITCH_DELTA = 18;
+/** Absolute bench score required to take a proactive switch. */
+const PROACTIVE_SWITCH_FLOOR = 12;
 
 /** Lazy `Dex.moves.get`. */
 function moveOf(id: string) {
@@ -308,20 +318,33 @@ export class HeuristicEngine implements Engine {
 		const foeStats = foeMon.stats;
 		const wereFaster = (myStats?.spe ?? 0) > (foeStats?.spe ?? 0);
 
-		const wantSwitch =
-			(myHp < FAINT_THRESHOLD && !wereFaster) ||
-			matchup.score < SWITCH_OUT_MATCHUP ||
-			((myMon.boosts.atk || 0) <= -3 && (myStats?.atk ?? 0) >= (myStats?.spa ?? 0)) ||
-			((myMon.boosts.spa || 0) <= -3 && (myStats?.spa ?? 0) >= (myStats?.atk ?? 0)) ||
-			(myHp < HP_SWITCH_OUT_THRESHOLD && matchup.score < 0);
-		if (!wantSwitch) return null;
-
-		// Find best candidate.
+		// Find best candidate so we can both rank it and use it for the
+		// proactive-synergy trigger below.
 		const best = chooseBestSwitch(
 			switchCandidates.map(c => c.mon),
 			foeMon,
 			tracker
 		);
+		const bestScore = best?.score.score ?? -Infinity;
+		// Proactive: even if the current matchup isn't *bad*, a bench
+		// mon might be drastically better. Only trip this when the
+		// current matchup is at least mildly unfavourable AND a bench
+		// mon clears a large absolute floor — otherwise we just flip-
+		// flop and feed the foe free turns.
+		const proactiveSwitch =
+			matchup.score < 0 &&
+			bestScore >= PROACTIVE_SWITCH_FLOOR &&
+			bestScore - matchup.score >= PROACTIVE_SWITCH_DELTA;
+
+		const wantSwitch =
+			(myHp < FAINT_THRESHOLD && !wereFaster) ||
+			matchup.score < SWITCH_OUT_MATCHUP ||
+			((myMon.boosts.atk || 0) <= -3 && (myStats?.atk ?? 0) >= (myStats?.spa ?? 0)) ||
+			((myMon.boosts.spa || 0) <= -3 && (myStats?.spa ?? 0) >= (myStats?.atk ?? 0)) ||
+			(myHp < HP_SWITCH_OUT_THRESHOLD && matchup.score < 0) ||
+			proactiveSwitch;
+		if (!wantSwitch) return null;
+
 		if (!best) return null;
 		const slot = switchCandidates.find(c => c.mon.id === best.mon.id);
 		if (!slot) return null;
@@ -467,28 +490,28 @@ export class HeuristicEngine implements Engine {
 			.filter((m): m is TrackedPokemon => !!m);
 
 		switch (target) {
-			case "normal":
-			case "any":
-			case "adjacentFoe": {
-				const t = pickTarget({
-					tracker,
-					attacker: myMon,
-					move,
-					foeSlots: foeSlotMons,
-					allySlots: allyMons,
-				});
-				return t !== null ? `move ${idx} ${t}${suffix}` : `move ${idx}${suffix}`;
-			}
-			case "adjacentAlly":
-				return `move ${idx} -${(slotIndex ^ 1) + 1}${suffix}`;
-			case "adjacentAllyOrSelf": {
-				const allyIndex = slotIndex ^ 1;
-				const ally = (request.side).pokemon[allyIndex];
-				const allyAlive = !!ally && !ally.condition.endsWith(" fnt");
-				return `move ${idx} -${(allyAlive ? allyIndex : slotIndex) + 1}${suffix}`;
-			}
-			default:
-				return `move ${idx}${suffix}`;
+		case "normal":
+		case "any":
+		case "adjacentFoe": {
+			const t = pickTarget({
+				tracker,
+				attacker: myMon,
+				move,
+				foeSlots: foeSlotMons,
+				allySlots: allyMons,
+			});
+			return t !== null ? `move ${idx} ${t}${suffix}` : `move ${idx}${suffix}`;
+		}
+		case "adjacentAlly":
+			return `move ${idx} -${(slotIndex ^ 1) + 1}${suffix}`;
+		case "adjacentAllyOrSelf": {
+			const allyIndex = slotIndex ^ 1;
+			const ally = (request.side).pokemon[allyIndex];
+			const allyAlive = !!ally && !ally.condition.endsWith(" fnt");
+			return `move ${idx} -${(allyAlive ? allyIndex : slotIndex) + 1}${suffix}`;
+		}
+		default:
+			return `move ${idx}${suffix}`;
 		}
 	}
 

--- a/sim/tools/strategic-ai/engines/HeuristicEngine.ts
+++ b/sim/tools/strategic-ai/engines/HeuristicEngine.ts
@@ -330,22 +330,47 @@ export class HeuristicEngine implements Engine {
 		// mon might be drastically better. Only trip this when the
 		// current matchup is at least mildly unfavourable AND a bench
 		// mon clears a large absolute floor — otherwise we just flip-
-		// flop and feed the foe free turns.
+		// flop and feed the foe free turns. The bench mon must also
+		// actually survive entry (so we don't sac into a 4× weakness
+		// for the speed/seed bonus).
+		const proactiveSurvives =
+			!best || best.score.foeDealFraction + best.score.hazardFraction < 0.9;
 		const proactiveSwitch =
 			matchup.score < 0 &&
 			bestScore >= PROACTIVE_SWITCH_FLOOR &&
-			bestScore - matchup.score >= PROACTIVE_SWITCH_DELTA;
+			bestScore - matchup.score >= PROACTIVE_SWITCH_DELTA &&
+			proactiveSurvives;
+
+		// "Don't waste a consumed-item activation": if the current mon
+		// is sitting on a fresh boost it paid for (Paradox boost from
+		// Booster Energy / matching weather/terrain, terrain-seed Def/
+		// SpD bump, Flash Fire / Charge, etc.) leaving it costs a real
+		// resource. Refuse non-emergency switches in that state.
+		const activatedBoostUp = hasActiveConsumableBoost(myMon, tracker);
+		const emergencySwitch =
+			(myHp < FAINT_THRESHOLD && !wereFaster) ||
+			((myMon.boosts.atk || 0) <= -3 && (myStats?.atk ?? 0) >= (myStats?.spa ?? 0)) ||
+			((myMon.boosts.spa || 0) <= -3 && (myStats?.spa ?? 0) >= (myStats?.atk ?? 0));
+		if (activatedBoostUp && !emergencySwitch) return null;
 
 		const wantSwitch =
-			(myHp < FAINT_THRESHOLD && !wereFaster) ||
+			emergencySwitch ||
 			matchup.score < SWITCH_OUT_MATCHUP ||
-			((myMon.boosts.atk || 0) <= -3 && (myStats?.atk ?? 0) >= (myStats?.spa ?? 0)) ||
-			((myMon.boosts.spa || 0) <= -3 && (myStats?.spa ?? 0) >= (myStats?.atk ?? 0)) ||
 			(myHp < HP_SWITCH_OUT_THRESHOLD && matchup.score < 0) ||
 			proactiveSwitch;
 		if (!wantSwitch) return null;
 
 		if (!best) return null;
+		// Sacrifice guard: refuse to "switch out" into a mon that the
+		// foe's best plausible attack would OHKO on entry. Without this
+		// the engine happily pivots a low-HP mon into a 4×-weak teammate
+		// just to set up a future swap — exactly the "swap-in, get KO'd,
+		// swap back" loop reported in playtest. Only the FAINT-emergency
+		// branch overrides this (we're already dying anyway, and the
+		// foe gets a free turn either way).
+		const candidateSurvives = best.score.foeDealFraction + best.score.hazardFraction < 0.95;
+		const isEmergency = myHp < FAINT_THRESHOLD && !wereFaster;
+		if (!candidateSurvives && !isEmergency) return null;
 		const slot = switchCandidates.find(c => c.mon.id === best.mon.id);
 		if (!slot) return null;
 		// Skill-gated: lower difficulty switches less reliably.
@@ -556,6 +581,58 @@ export class HeuristicEngine implements Engine {
 		// Fallback: synthesise a minimal record so we don't crash.
 		return null;
 	}
+}
+
+/**
+ * True if `mon` is currently enjoying a stat boost that was earned by
+ * consuming a single-use item or by entering a matching field (e.g.
+ * Booster Energy / sun on Protosynthesis, Electric Terrain on Quark
+ * Drive, Grassy/Electric/Misty/Psychic Seed in the matching terrain,
+ * Flash Fire / Charge volatile up).
+ *
+ * Switching out throws that resource away — the seed is already gone,
+ * Booster Energy was consumed on entry, etc. — so the caller uses this
+ * as a soft veto against non-emergency switches.
+ *
+ * @param mon Tracked Pokemon snapshot for the active mon.
+ * @param tracker Battle state tracker (for current field state).
+ * @returns true when a consumed-item or field-activated boost is up.
+ */
+function hasActiveConsumableBoost(
+	mon: TrackedPokemon,
+	tracker: BattleStateTracker
+): boolean {
+	for (const v of mon.volatiles) {
+		if (v.startsWith("protosynthesis") || v.startsWith("quarkdrive")) return true;
+		if (v === "flashfire" || v === "charge") return true;
+	}
+	const ability = toID(mon.ability);
+	const weather = tracker.field.weather;
+	const terrain = tracker.field.terrain;
+	const protoActive = ability === "protosynthesis" &&
+		(weather === "sunnyday" || weather === "desolateland");
+	const quarkActive = ability === "quarkdrive" && terrain === "electricterrain";
+	if (protoActive || quarkActive) return true;
+	// Terrain-seed users keep their +1 Def/SpD boost for the duration of
+	// the stay; the item has already been consumed by the time we get
+	// here, so we infer "boost up" from the boost stage matching the
+	// expected stat. Best-effort: a real Defiant trigger could also leave
+	// these stages up, but the conservatism cost is small.
+	if (
+		(terrain === "grassyterrain" || terrain === "electricterrain") &&
+		(mon.boosts.def ?? 0) > 0 &&
+		!mon.item
+	) {
+		return true;
+	}
+	if (
+		(terrain === "mistyterrain" || terrain === "psychicterrain") &&
+		(mon.boosts.spd ?? 0) > 0 &&
+		!mon.item
+	) {
+		return true;
+	}
+	return false;
 }
 
 /** Re-export the small helper consumers may want. */

--- a/sim/tools/strategic-ai/mechanics/DamageCalc.ts
+++ b/sim/tools/strategic-ai/mechanics/DamageCalc.ts
@@ -618,18 +618,23 @@ function computeOffensiveStat(move: Move, input: DamageCalcInput): number {
 	const physical = isPhysicalForCalc(move, input);
 	const crit = !!input.forceCrit;
 	let baseStat: number;
+	let offensiveStatKey: keyof StatBlock;
 	if (id === "bodypress") {
+		offensiveStatKey = "def";
 		baseStat = effectiveStat(input.attacker, "def", /* ignoreNeg */ crit);
 	} else if (id === "foulplay") {
 		// Foul Play reads the defender's attack as if it were the user's,
 		// so the attacker-side crit rule (ignore negative stages) applies.
+		offensiveStatKey = "atk";
 		baseStat = effectiveStat(input.defender, "atk", /* ignoreNeg */ crit);
 	} else if (id === "photongeyser") {
 		const atk = effectiveStat(input.attacker, "atk", /* ignoreNeg */ crit);
 		const spa = effectiveStat(input.attacker, "spa", /* ignoreNeg */ crit);
+		offensiveStatKey = atk >= spa ? "atk" : "spa";
 		baseStat = Math.max(atk, spa);
 	} else {
-		baseStat = effectiveStat(input.attacker, physical ? "atk" : "spa", /* ignoreNeg */ crit);
+		offensiveStatKey = physical ? "atk" : "spa";
+		baseStat = effectiveStat(input.attacker, offensiveStatKey, /* ignoreNeg */ crit);
 	}
 	const ability = toID(input.attacker.ability);
 	if ((ability === "hugepower" || ability === "purepower") && physical) baseStat *= 2;
@@ -640,6 +645,25 @@ function computeOffensiveStat(move: Move, input: DamageCalcInput): number {
 		(move.type === "Fire" || resolveMoveType(move, input) === "Fire")
 	) {
 		baseStat *= 1.5;
+	}
+	// Solar Power: +50% Special Attack in harsh sunlight.
+	const offensiveWeather = effectiveWeather(input.field, input.attacker, input.defender);
+	if (
+		ability === "solarpower" &&
+		!physical &&
+		(offensiveWeather === "sunnyday" || offensiveWeather === "desolateland")
+	) {
+		baseStat *= 1.5;
+	}
+	// Protosynthesis (sun / Booster Energy) and Quark Drive (electric
+	// terrain / Booster Energy) grant a +30% boost (+50% to Speed) to
+	// the user's highest stat. We approximate "highest stat" from the
+	// stat block (best-known) or the species' base stats, defaulting to
+	// the offensive stat if the species lookup fails so the boost still
+	// applies in the common case.
+	const paradoxBoosted = paradoxBoostedStat(input.attacker, ability, input.field);
+	if (paradoxBoosted && paradoxBoosted === offensiveStatKey) {
+		baseStat *= paradoxBoostedMultiplier(paradoxBoosted);
 	}
 	const item = toID(input.attacker.item);
 	if (item === "choiceband" && physical) baseStat *= 1.5;
@@ -680,7 +704,105 @@ function computeDefensiveStat(move: Move, input: DamageCalcInput): number {
 	if (isSnow && stat === "def" && input.defender.types.includes("Ice")) {
 		value *= 1.5;
 	}
+	// Protosynthesis/Quark Drive defensive boost: applies whenever the
+	// defender's "highest stat" happens to be the relevant defensive
+	// stat (Def for Physical, SpD for Special / Psyshock-family).
+	const defAbility = toID(input.defender.ability);
+	const paradoxBoosted = paradoxBoostedStat(input.defender, defAbility, input.field);
+	if (paradoxBoosted && paradoxBoosted === stat) {
+		value *= paradoxBoostedMultiplier(paradoxBoosted);
+	}
 	return value;
+}
+
+/**
+ * Return the stat that a Protosynthesis / Quark Drive user is currently
+ * boosting, or `null` if the ability isn't active.
+ *
+ * The boost activates when:
+ *
+ * - **Protosynthesis** holder is in harsh sun, or holds Booster Energy
+ *   (which the mon consumes on switch-in; until the calc sees the
+ *   item as consumed we treat presence-of-item as proof it'll fire).
+ * - **Quark Drive** holder is in Electric Terrain, or holds Booster
+ *   Energy under the same logic.
+ *
+ * The boosted stat is the user's highest stat after positive stat
+ * stages (per Showdown's `getActiveProto` rule). We approximate from
+ * the best-known stat block; when none is known we fall back to the
+ * species' base stats so the boost still kicks in for foe mons whose
+ * EV spread isn't visible to us.
+ *
+ * @param mon The Pokemon snapshot to evaluate.
+ * @param ability The mon's currently-active ability id.
+ * @param field The battle field state (used for weather/terrain check).
+ * @returns The boosted stat key, or `null` when not active.
+ */
+function paradoxBoostedStat(
+	mon: CalcPokemon,
+	ability: string,
+	field: FieldState
+): keyof StatBlock | null {
+	const isProto = ability === "protosynthesis";
+	const isQuark = ability === "quarkdrive";
+	if (!isProto && !isQuark) return null;
+	// Volatile already records the boosted stat — prefer it when present.
+	// Showdown emits `|-start|...|protosynthesis|atk` etc., so the
+	// tracker stores `protosynthesisatk` / `quarkdriveatk` style ids.
+	if (mon.volatiles) {
+		for (const v of mon.volatiles) {
+			if (!v.startsWith("protosynthesis") && !v.startsWith("quarkdrive")) continue;
+			const stat = v.slice(v.startsWith("protosynthesis") ? "protosynthesis".length : "quarkdrive".length);
+			if (isStatKey(stat)) return stat;
+		}
+	}
+	const weather = field.weather;
+	const terrain = field.terrain;
+	const item = toID(mon.item);
+	const sun = weather === "sunnyday" || weather === "desolateland";
+	const eTerrain = terrain === "electricterrain";
+	const booster = item === "boosterenergy";
+	const activeForProto = isProto && (sun || booster);
+	const activeForQuark = isQuark && (eTerrain || booster);
+	if (!activeForProto && !activeForQuark) return null;
+	return highestNonHpStat(mon);
+}
+
+/**
+ * Multiplier applied by Protosynthesis / Quark Drive to the chosen
+ * stat. Speed receives a 1.5× multiplier; offensive/defensive stats
+ * receive 1.3×. The HP boost case never applies because the ability
+ * deliberately skips HP when picking its target stat.
+ *
+ * @param stat The stat key the ability boosted.
+ * @returns The multiplicative scale factor.
+ */
+function paradoxBoostedMultiplier(stat: keyof StatBlock): number {
+	if (stat === "spe") return 1.5;
+	return 1.3;
+}
+
+function highestNonHpStat(mon: CalcPokemon): keyof StatBlock {
+	const stats = ensureStats(mon);
+	// Effective post-positive-stage stats (Showdown's
+	// `getActiveProto` definition). Negative stages are ignored.
+	const keys: (keyof StatBlock)[] = ["atk", "def", "spa", "spd", "spe"];
+	let best: keyof StatBlock = "atk";
+	let bestVal = -Infinity;
+	for (const k of keys) {
+		const stage = Math.max(0, mon.boosts?.[k] || 0);
+		const base = stats[k] || 1;
+		const adjusted = stage > 0 ? Math.floor(base * (2 + stage) / 2) : base;
+		if (adjusted > bestVal) {
+			bestVal = adjusted;
+			best = k;
+		}
+	}
+	return best;
+}
+
+function isStatKey(v: string): v is keyof StatBlock {
+	return v === "hp" || v === "atk" || v === "def" || v === "spa" || v === "spd" || v === "spe";
 }
 
 /**

--- a/sim/tools/strategic-ai/mechanics/DamageCalc.ts
+++ b/sim/tools/strategic-ai/mechanics/DamageCalc.ts
@@ -740,8 +740,12 @@ function computeOffensiveStat(move: Move, input: DamageCalcInput): number {
 	// stat block (best-known) or the species' base stats, defaulting to
 	// the offensive stat if the species lookup fails so the boost still
 	// applies in the common case.
-	const paradoxBoosted = paradoxBoostedStat(input.attacker, ability, input.field);
-	if (paradoxBoosted && paradoxBoosted === offensiveStatKey) {
+	const paradoxBoosted = paradoxBoostedStat(input.attacker, ability, input.field, offensiveWeather);
+	// Foul Play attacks with the *defender's* Attack stat, so the user's
+	// own Protosynthesis / Quark Drive Attack boost must not be folded
+	// back in — that would make a boosted Foul Play user hit far harder
+	// than it really does.
+	if (paradoxBoosted && paradoxBoosted === offensiveStatKey && id !== "foulplay") {
 		baseStat *= paradoxBoostedMultiplier(paradoxBoosted);
 	}
 	const item = toID(input.attacker.item);
@@ -787,7 +791,7 @@ function computeDefensiveStat(move: Move, input: DamageCalcInput): number {
 	// defender's "highest stat" happens to be the relevant defensive
 	// stat (Def for Physical, SpD for Special / Psyshock-family).
 	const defAbility = toID(input.defender.ability);
-	const paradoxBoosted = paradoxBoostedStat(input.defender, defAbility, input.field);
+	const paradoxBoosted = paradoxBoostedStat(input.defender, defAbility, input.field, weather);
 	if (paradoxBoosted && paradoxBoosted === stat) {
 		value *= paradoxBoostedMultiplier(paradoxBoosted);
 	}
@@ -814,13 +818,17 @@ function computeDefensiveStat(move: Move, input: DamageCalcInput): number {
  *
  * @param mon The Pokemon snapshot to evaluate.
  * @param ability The mon's currently-active ability id.
- * @param field The battle field state (used for weather/terrain check).
+ * @param field The battle field state (used for the terrain check).
+ * @param effWeather The *effective* weather id (i.e. after Cloud Nine /
+ *   Air Lock suppression), so Protosynthesis doesn't activate under sun
+ *   that's currently being negated.
  * @returns The boosted stat key, or `null` when not active.
  */
 function paradoxBoostedStat(
 	mon: CalcPokemon,
 	ability: string,
-	field: FieldState
+	field: FieldState,
+	effWeather: string
 ): keyof StatBlock | null {
 	const isProto = ability === "protosynthesis";
 	const isQuark = ability === "quarkdrive";
@@ -835,10 +843,12 @@ function paradoxBoostedStat(
 			if (isStatKey(stat)) return stat;
 		}
 	}
-	const weather = field.weather;
 	const terrain = field.terrain;
 	const item = toID(mon.item);
-	const sun = weather === "sunnyday" || weather === "desolateland";
+	// Use the effective weather so Cloud Nine / Air Lock correctly
+	// suppress sun-based Protosynthesis activation. (Electric Terrain
+	// isn't weather, so Cloud Nine / Air Lock don't touch Quark Drive.)
+	const sun = effWeather === "sunnyday" || effWeather === "desolateland";
 	const eTerrain = terrain === "electricterrain";
 	const booster = item === "boosterenergy";
 	const activeForProto = isProto && (sun || booster);

--- a/sim/tools/strategic-ai/mechanics/DamageCalc.ts
+++ b/sim/tools/strategic-ai/mechanics/DamageCalc.ts
@@ -124,6 +124,37 @@ export interface DamageCalcInput {
 	 * `Dex.gen`.
 	 */
 	gen?: number;
+	/**
+	 * True when the attacker is expected to move before the defender
+	 * this turn. Used by power-doubling moves whose effect depends on
+	 * turn order: Bolt Beak / Fishious Rend (`true` → 2× BP), Payback /
+	 * Revenge / Avalanche (`false` → 2× BP), Assurance (foe took damage
+	 * this turn → 2× BP, approximated downstream by combining this with
+	 * `defenderTookDamageThisTurn`).
+	 *
+	 * Falsy (undefined) means "unknown"; the calc falls back to neutral
+	 * scaling (no boost, no penalty).
+	 */
+	attackerMovesFirst?: boolean;
+	/**
+	 * True when the attacker's previous successful move attempt failed
+	 * (missed / immune / blocked). Used by Stomping Tantrum (2× BP) so
+	 * the AI sequences "Earthquake against Levitate → Stomping Tantrum"
+	 * intentionally instead of treating the first turn as a sunk loss.
+	 */
+	attackerLastMoveFailed?: boolean;
+	/**
+	 * True when one of the attacker's stat stages was lowered this turn
+	 * (Intimidate switch-in, Sticky Web entry, foe Sword Dance, etc.).
+	 * Used by Lash Out (2× BP).
+	 */
+	attackerLostStatThisTurn?: boolean;
+	/**
+	 * True when the defender has already been hit by another move this
+	 * turn (doubles partner, prior multi-hit, etc.). Used by Assurance
+	 * (2× BP).
+	 */
+	defenderTookDamageThisTurn?: boolean;
 }
 
 /** Output of {@link calculateDamage}. */
@@ -174,6 +205,16 @@ export function calculateDamage(input: DamageCalcInput): DamageRange {
 	const move = typeof input.move === "string" ? Dex.moves.get(input.move) : input.move;
 	const moveId = toID(move.id || (move as { name: string }).name || "");
 	const defenderHp = estimateMaxHp(input.defender);
+	// Always-crit moves (Wicked Blow, Surging Strikes, Flower Trick,
+	// Storm Throw, Frost Breath, Zippy Zap, ...) carry `willCrit: true`
+	// in dex data. Auto-promote them to `forceCrit` so callers don't
+	// have to know which moves are guaranteed: a Wicked Blow into a
+	// +6 Iron Defense Cosmoem still does its full chip because crit
+	// ignores foe positive Def stages (see `effectiveStat`).
+	const guaranteedCrit = move && (move as { willCrit?: boolean }).willCrit === true;
+	if (guaranteedCrit && !input.forceCrit) {
+		input = { ...input, forceCrit: true };
+	}
 	const baseRange: DamageRange = {
 		minDamage: 0,
 		avgDamage: 0,
@@ -544,8 +585,46 @@ function computeBasePower(move: Move, moveType: string, input: DamageCalcInput):
 			break;
 		case "boltbeak":
 		case "fishiousrend":
-			// We don't know move order; approximate as 50% chance of doubling.
-			bp *= 1.5;
+			// 2× if the attacker moves first this turn — we now have
+			// the hint from the caller. When the hint is missing
+			// (`undefined`), fall back to the historical 1.5× midpoint
+			// estimate rather than guess wrong either way.
+			if (input.attackerMovesFirst === true) bp *= 2;
+			else if (input.attackerMovesFirst === undefined) bp *= 1.5;
+			break;
+		case "payback":
+			// 2× if the attacker moves second.
+			if (input.attackerMovesFirst === false) bp *= 2;
+			break;
+		case "revenge":
+		case "avalanche":
+			// 2× if the attacker took damage from the foe this turn.
+			// We approximate that as "foe moves first" — the typical
+			// scenario where Revenge / Avalanche actually fire. (False
+			// positives in the unusual "foe used a status move first
+			// turn" case are tolerable; the scoring layer cross-checks
+			// `defender.lastMove?.category` for the higher-value
+			// branches.)
+			if (input.attackerMovesFirst === false) bp *= 2;
+			break;
+		case "assurance":
+			// 2× if the target has already taken damage this turn —
+			// classic doubles partner combo, or any prior hit on the
+			// same target in singles (multi-hit interruption, etc.).
+			if (input.defenderTookDamageThisTurn) bp *= 2;
+			break;
+		case "lashout":
+			// 2× if the attacker's stat stages were lowered this turn
+			// (Intimidate switch-in, Sticky Web, foe Sword Dance/Snarl).
+			if (input.attackerLostStatThisTurn) bp *= 2;
+			break;
+		case "stompingtantrum":
+			// 2× if the user's *previous* move failed. The engine sets
+			// this flag from `lastMoveFailedByMon` (LogParser feeds it
+			// from `|miss|` / `|-immune|` / `|cant|` events). The
+			// classic "Earthquake into Levitate → Stomping Tantrum"
+			// combo finally scores correctly.
+			if (input.attackerLastMoveFailed) bp *= 2;
 			break;
 		case "lastrespects":
 			// Scales with team faints; approximate with +1 per faint.

--- a/sim/tools/strategic-ai/mechanics/MoveEvaluator.ts
+++ b/sim/tools/strategic-ai/mechanics/MoveEvaluator.ts
@@ -73,6 +73,14 @@ export function evaluateMove(
 	if (!m || !moveId) {
 		return { moveId, score: -Infinity, rationale: "unknown" };
 	}
+	// Counter-style moves use `damageCallback` with `basePower: 0`, so the
+	// normal damage path scores them at 0. Handle them up-front: they're
+	// only good in narrow situations (foe just hit us with the right
+	// category and we'd survive another hit), but they're game-winning
+	// when they line up.
+	if (moveId === "counter" || moveId === "mirrorcoat" || moveId === "metalburst") {
+		return evaluateCounterMove(m, moveId, ctx);
+	}
 	if (m.category === "Status") {
 		return evaluateStatus(m, moveId, ctx);
 	}
@@ -288,12 +296,29 @@ function evaluateStatus(
 		return { moveId, score, rationale: "taunt" };
 	}
 	if (moveId === "encore") {
-		score = defender.lastMove ? 14 : -5;
+		score = scoreEncore(ctx);
 		return { moveId, score, rationale: "encore" };
 	}
 	if (moveId === "disable") {
 		score = defender.lastMove ? 10 : -5;
 		return { moveId, score, rationale: "disable" };
+	}
+
+	// Destiny Bond — only worth it as a desperation trade when we expect
+	// to die this turn anyway. Showdown also rejects two DBs in a row,
+	// so refuse if our DB volatile is already up.
+	if (moveId === "destinybond") {
+		score = scoreDestinyBond(ctx);
+		return { moveId, score, rationale: "destinybond" };
+	}
+
+	// Baton Pass — pivot that *also* transfers boosts. The legacy fallback
+	// scored this at 2, so the AI would hoard boosts on one mon instead of
+	// passing them. Score is dominated by the value of the boosts being
+	// passed plus the value of our best switch target.
+	if (moveId === "batonpass") {
+		score = scoreBatonPass(ctx);
+		return { moveId, score, rationale: "batonpass" };
 	}
 
 	// Wish / Healing Wish / Memento.
@@ -327,22 +352,22 @@ function evaluateStatus(
 function isRecoveryMove(moveId: string, move: Move): boolean {
 	if (move.heal) return true;
 	switch (moveId) {
-		case "recover":
-		case "softboiled":
-		case "milkdrink":
-		case "moonlight":
-		case "morningsun":
-		case "synthesis":
-		case "roost":
-		case "shoreup":
-		case "slackoff":
-		case "rest":
+	case "recover":
+	case "softboiled":
+	case "milkdrink":
+	case "moonlight":
+	case "morningsun":
+	case "synthesis":
+	case "roost":
+	case "shoreup":
+	case "slackoff":
+	case "rest":
 		// `wish` is intentionally NOT here: it has a dedicated branch in
 		// `evaluateStatus` (delayed self-heal scoring) that would otherwise
 		// be unreachable.
-		case "healorder":
-		case "lifedew":
-			return true;
+	case "healorder":
+	case "lifedew":
+		return true;
 	}
 	return false;
 }
@@ -401,25 +426,168 @@ function scoreStatusInfliction(status: string, ctx: MoveEvalContext): number {
 	const { defender } = ctx;
 	if (defender.status) return -10; // Already statused.
 	switch (status) {
-		case "tox":
-		case "psn": {
-			if (defender.types.includes("Steel") || defender.types.includes("Poison")) return -20;
-			return 16;
-		}
-		case "brn": {
-			if (defender.types.includes("Fire")) return -20;
-			return 14;
-		}
-		case "par": {
-			if (defender.types.includes("Electric") || defender.types.includes("Ground")) return -20;
-			return ctx.weOutspeed ? 6 : 14;
-		}
-		case "slp": {
-			return 18;
-		}
-		case "frz": return 6; // Rare.
+	case "tox":
+	case "psn": {
+		if (defender.types.includes("Steel") || defender.types.includes("Poison")) return -20;
+		return 16;
+	}
+	case "brn": {
+		if (defender.types.includes("Fire")) return -20;
+		return 14;
+	}
+	case "par": {
+		if (defender.types.includes("Electric") || defender.types.includes("Ground")) return -20;
+		return ctx.weOutspeed ? 6 : 14;
+	}
+	case "slp": {
+		return 18;
+	}
+	case "frz": return 6; // Rare.
 	}
 	return 4;
+}
+
+/**
+ * Score Counter / Mirror Coat / Metal Burst.
+ *
+ * These moves are non-Status but use `damageCallback` with `basePower: 0`,
+ * so the standard damage path returns 0. They're only useful in a narrow
+ * situation: the foe just hit us with a matching attack category and
+ * we're slower (so we'll bank a hit, then strike back for 2x its damage).
+ *
+ * Metal Burst is bidirectional (works on either category) and only fires
+ * after we've taken damage that turn, so its scoring is slightly more
+ * lenient about category prediction.
+ *
+ * @param move The move definition.
+ * @param moveId The move id (`counter`, `mirrorcoat`, or `metalburst`).
+ * @param ctx The move evaluation context.
+ * @returns A `MoveEvaluation` whose `score` represents this move's utility.
+ */
+function evaluateCounterMove(
+	move: Move,
+	moveId: string,
+	ctx: MoveEvalContext
+): MoveEvaluation {
+	const { attacker, defender } = ctx;
+	// Required category that the foe must hit us with for this to fire.
+	const requiredFoeCategory: "Physical" | "Special" | "Any" =
+		moveId === "counter" ? "Physical" :
+		moveId === "mirrorcoat" ? "Special" : "Any";
+	const foeLast = defender.lastMove ? Dex.moves.get(defender.lastMove) : null;
+	const foeLastCategory = foeLast?.category;
+	// Outspeeding means we go before the foe can hit us this turn, and
+	// counters reflect "damage taken this turn" — so outspeeding makes
+	// them whiff. The move is best when we're slower.
+	const slower = !ctx.weOutspeed;
+	let score: number;
+	let rationale = moveId;
+	const matches =
+		requiredFoeCategory === "Any" ||
+		(foeLastCategory && foeLastCategory === requiredFoeCategory);
+	if (matches && slower) {
+		// Foe is committed (e.g. Choice-locked) makes this almost guaranteed.
+		score = defender.choiceLocked ? 55 : 35;
+		rationale = `${moveId}:setup`;
+	} else if (matches) {
+		score = 12;
+	} else if (foeLastCategory) {
+		// Foe just used the opposite category — predicting they'll do it
+		// again is a coin-flip; mildly negative so it's not the top pick
+		// but still considered.
+		score = -4;
+	} else {
+		// No info on the foe yet (turn 1, fresh switch-in). Modest baseline
+		// so it can outscore truly useless moves but isn't a default pick.
+		score = 4;
+	}
+	// Health gate: must survive a hit to retaliate.
+	if ((attacker.hpFraction ?? 1) < 0.25) score -= 20;
+	return { moveId, score, damage: undefined, rationale };
+}
+
+/**
+ * Score Encore. Locking the foe is best when they just used a non-damaging
+ * move (setup, status, hazard) — we deny them a damaging turn. Locking
+ * them into a damaging move they just used is mildly useful (predictability)
+ * but a wasted turn against pure attackers.
+ *
+ * @param ctx The move evaluation context.
+ * @returns The Encore utility score (~ -5..28 range).
+ */
+function scoreEncore(ctx: MoveEvalContext): number {
+	const { defender } = ctx;
+	if (!defender.lastMove) return -5;
+	if (defender.choiceLocked) return -2; // Foe is already locked into one move.
+	const lastMove = Dex.moves.get(defender.lastMove);
+	if (!lastMove?.exists) return 4;
+	if (lastMove.category === "Status") {
+		// Locking a setup or hazard mon out of attacking is huge.
+		return 28;
+	}
+	return 8;
+}
+
+/**
+ * Score Destiny Bond. Only valuable as a desperation trade: we expect
+ * to faint this turn anyway, so we take the foe with us. Showdown
+ * disallows two DBs in a row, so refuse if our DB volatile is up.
+ *
+ * @param ctx The move evaluation context.
+ * @returns The Destiny Bond utility score.
+ */
+function scoreDestinyBond(ctx: MoveEvalContext): number {
+	const { attacker } = ctx;
+	if (attacker.volatiles.has("destinybond")) return -25;
+	const myHp = attacker.hpFraction ?? 1;
+	const foeFaster = !ctx.weOutspeed;
+	// Critical HP + foe outspeeds + foe is a likely KO threat — trade.
+	if (myHp < 0.25 && foeFaster) return 55;
+	if (myHp < 0.4 && foeFaster) return 18;
+	// Healthy: DB is wasted turn (foe just keeps not attacking).
+	return -10;
+}
+
+/**
+ * Score Baton Pass.
+ *
+ * Two utility sources stack:
+ *
+ * 1. Boosts the user is currently holding (each +1 stage worth a stage-
+ *    weighted amount — same valuation as a self-boost move).
+ * 2. The matchup value of the best switch target receiving those boosts
+ *    (we don't waste BP into a 4x weak mon).
+ *
+ * Without boosts to pass and without a meaningful switch-in, BP is
+ * essentially U-turn without damage — modestly negative.
+ *
+ * @param ctx The move evaluation context.
+ * @returns The Baton Pass utility score.
+ */
+function scoreBatonPass(ctx: MoveEvalContext): number {
+	const { attacker } = ctx;
+	// Value of boosts being passed. We weight offensive stages high
+	// because that's the whole point of a BP chain; speed is also
+	// strong (Agility/Dragon Dance pass).
+	let boostValue = 0;
+	for (const [stat, raw] of Object.entries(attacker.boosts)) {
+		const stage = Math.max(0, raw);
+		if (!stage) continue;
+		const perStage = stat === "spe" ? 12 : (stat === "atk" || stat === "spa") ? 11 : 6;
+		boostValue += stage * perStage;
+	}
+	const switchValue = ctx.valueOfBestSwitch ?? 0;
+	// If we have boosts, passing them is excellent — easily dominate the
+	// fallback "+2" tier and most attacking options. Without boosts,
+	// scale by the switch value so we still consider BP as a pivot.
+	if (boostValue > 0) {
+		return boostValue + Math.max(0, switchValue) * 0.6 + 8;
+	}
+	// No boosts: BP becomes a no-damage pivot. Mildly positive only if
+	// the switch target is genuinely good and we don't have a better
+	// attacking option (the engine will compare scores).
+	if (switchValue > 8) return switchValue * 0.5;
+	return -8;
 }
 
 function hazardSetValue(ctx: MoveEvalContext, hazard: string): number {

--- a/sim/tools/strategic-ai/mechanics/MoveEvaluator.ts
+++ b/sim/tools/strategic-ai/mechanics/MoveEvaluator.ts
@@ -46,6 +46,13 @@ export interface MoveEvalContext {
 	isDoubles: boolean;
 	/** Optional pre-computed value of our best switch-in for pivot scoring. */
 	valueOfBestSwitch?: number;
+	/**
+	 * True if our attacker's previous move attempt failed (missed,
+	 * blocked by immunity, blocked by Protect, etc.). Engine fills this
+	 * from `engineCtx.lastMoveFailedByMon` so power-doubling moves like
+	 * Stomping Tantrum can be scored at their boosted value.
+	 */
+	attackerLastMoveFailed?: boolean;
 }
 
 /** Result of a move evaluation. */
@@ -103,6 +110,16 @@ export function evaluateMove(
 		attackerSide: tracker.sides[ctx.mySide],
 		defenderSide: tracker.sides[ctx.foeSide],
 		isDoubles: ctx.isDoubles,
+		attackerMovesFirst: ctx.weOutspeed,
+		attackerLastMoveFailed: ctx.attackerLastMoveFailed,
+		// Approximations for conditional-BP moves where exact per-turn
+		// tracking would be expensive. Both have low false-positive
+		// cost — at worst a slightly over-scored Lash Out / Assurance.
+		attackerLostStatThisTurn: hasActiveNegativeBoost(attacker),
+		// In singles we don't track per-turn hits on the foe; leaving
+		// this `false` keeps Assurance honest (base BP) unless a future
+		// caller threads it in for doubles partner combos.
+		defenderTookDamageThisTurn: false,
 	});
 	const maxHp = calc.defenderMaxHp || estimateMaxHp(fromTracked(defender));
 	const damageScore = (calc.avgDamage / Math.max(1, maxHp)) * 100; // 0..100ish
@@ -256,22 +273,28 @@ function evaluateStatus(
 		return { moveId, score, rationale };
 	}
 
-	// Hazard moves.
+	// Hazard moves. Priority order (tuned per playtest feedback):
+	//   Sticky Web > Stealth Rock > Toxic Spikes > Spikes
+	// Sticky Web wins because the -1 Spe stage every switch-in takes
+	// reshapes the rest of the battle (a slow team suddenly outspeeds);
+	// SR is the universal chip; T-Spikes punishes grounded non-Poison
+	// foes with passive damage that compounds with switches; Spikes are
+	// last because they only fire on grounded mons and stack slowly.
+	if (moveId === "stickyweb") {
+		if (foeSideState.stickyWeb) return { moveId, score: -10, rationale: "hazardSet" };
+		return { moveId, score: hazardSetValue(ctx, "stickyweb"), rationale: "hazard:web" };
+	}
 	if (moveId === "stealthrock") {
 		if (foeSideState.stealthRock) return { moveId, score: -10, rationale: "hazardSet" };
 		return { moveId, score: hazardSetValue(ctx, "stealthrock"), rationale: "hazard:sr" };
-	}
-	if (moveId === "spikes") {
-		if (foeSideState.spikes >= 3) return { moveId, score: -10, rationale: "hazardCap" };
-		return { moveId, score: hazardSetValue(ctx, "spikes"), rationale: "hazard:spikes" };
 	}
 	if (moveId === "toxicspikes") {
 		if (foeSideState.toxicSpikes >= 2) return { moveId, score: -10, rationale: "hazardCap" };
 		return { moveId, score: hazardSetValue(ctx, "toxicspikes"), rationale: "hazard:tspikes" };
 	}
-	if (moveId === "stickyweb") {
-		if (foeSideState.stickyWeb) return { moveId, score: -10, rationale: "hazardSet" };
-		return { moveId, score: hazardSetValue(ctx, "stickyweb"), rationale: "hazard:web" };
+	if (moveId === "spikes") {
+		if (foeSideState.spikes >= 3) return { moveId, score: -10, rationale: "hazardCap" };
+		return { moveId, score: hazardSetValue(ctx, "spikes"), rationale: "hazard:spikes" };
 	}
 
 	// Hazard removal.
@@ -391,6 +414,60 @@ function evaluateStatus(
 		return { moveId, score, rationale: "trick" };
 	}
 
+	// Yawn — delayed sleep that gives the foe one turn of warning. The
+	// stall-tier value of Yawn is *forcing a switch*: the foe either
+	// stays in and falls asleep, or pivots and gives us free entry.
+	// Compounds well with Protect (burn a turn while the timer ticks)
+	// and with hazards on the foe side (any forced switch eats chip).
+	if (moveId === "yawn") {
+		if (defender.status) return { moveId, score: -10, rationale: "yawnRedundant" };
+		if (tracker.field.terrain === "electricterrain" || tracker.field.terrain === "mistyterrain") {
+			return { moveId, score: -10, rationale: "yawnTerrainBlocked" };
+		}
+		if (attacker.volatiles.has("yawn") || defender.volatiles.has("yawn")) {
+			return { moveId, score: -10, rationale: "yawnAlreadyUp" };
+		}
+		let yawnScore = 18;
+		// Stall combo: Protect lets us burn the foe's "awake" turn so
+		// sleep lands without giving them a free attack.
+		const stallMyMoves = attacker.revealedMoves;
+		const hasProtect = stallMyMoves.has("protect") ||
+			stallMyMoves.has("kingsshield") || stallMyMoves.has("spikyshield");
+		if (hasProtect) yawnScore += 8;
+		// Hazards already up on the foe side punish the forced switch.
+		const foeSideHere = tracker.sides[ctx.foeSide];
+		if (foeSideHere.stealthRock || foeSideHere.spikes || foeSideHere.stickyWeb) {
+			yawnScore += 4;
+		}
+		return { moveId, score: yawnScore, rationale: "yawn" };
+	}
+
+	// Endure — only valuable when we're holding a pinch berry / sash
+	// that we *want* to trigger, or as a desperation play with the
+	// foe outspeeding for a KO and a teammate ready to revenge.
+	if (moveId === "endure") {
+		const item = toID(attacker.item);
+		const endureHp = attacker.hpFraction ?? 1;
+		const pinchBerry =
+			item === "salacberry" || item === "liechiberry" ||
+			item === "petayaberry" || item === "ganlonberry" ||
+			item === "apicotberry";
+		if (attacker.volatiles.has("endure") || attacker.volatiles.has("protect")) {
+			return { moveId, score: -15, rationale: "endureRepeat" };
+		}
+		if (pinchBerry && endureHp < 0.6 && endureHp > 0.1) {
+			return { moveId, score: 22, rationale: "endurePinchSetup" };
+		}
+		if (item === "focussash" && endureHp > 0.95) {
+			// Sash is already going to save us; Endure is redundant.
+			return { moveId, score: -5, rationale: "endureSashRedundant" };
+		}
+		if (endureHp < 0.25 && !ctx.weOutspeed) {
+			return { moveId, score: 8, rationale: "endureDesperation" };
+		}
+		return { moveId, score: -5, rationale: "endureUnnecessary" };
+	}
+
 	// Fallback: small positive value so the AI considers exotic status moves
 	// rather than ignoring them entirely.
 	return { moveId, score: 2, rationale: "unknownStatus" };
@@ -427,23 +504,146 @@ function scoreBoostMove(
 	const boosts = move.self?.boosts ?? move.boosts ?? {};
 	const myBoosts = ctx.attacker.boosts;
 	let score = 0;
+	let anyMeaningful = false;
+	let boostsSpeed = false;
 	for (const [stat, amount] of Object.entries(boosts)) {
 		if (typeof amount !== "number") continue;
 		const cur = myBoosts[stat] || 0;
 		// Diminishing returns: +1 from 0 is more valuable than +1 from +5.
 		const incremental = amount > 0 ? Math.max(0, 6 - cur) / 6 : 1;
 		const stageValue = stat === "spe" ? 12 : (stat === "atk" || stat === "spa" ? 9 : 6);
-		score += amount * stageValue * incremental;
+		const contribution = amount * stageValue * incremental;
+		score += contribution;
+		if (contribution >= 4) anyMeaningful = true;
+		if (stat === "spe" && amount > 0 && cur < 6) boostsSpeed = true;
 	}
 	if (moveId === "bellydrum") {
 		score = (ctx.attacker.hpFraction ?? 1) >= 0.55 ? 60 : -20;
+		anyMeaningful = true;
 	}
 	if (moveId === "shellsmash") {
 		score = 35;
+		anyMeaningful = true;
+		boostsSpeed = true;
 	}
 	// Boost moves are awful when we're about to die.
 	if ((ctx.attacker.hpFraction ?? 1) < 0.25) score -= 10;
+	// Setup-window bonus: when our active mon is essentially locked
+	// in to surviving the next hit (Focus Sash @ full HP, Sturdy @
+	// full HP, Weakness Policy holder with foe revealed a SE move,
+	// Unburden holder pre-activation), double down on the setup pick
+	// instead of attacking. This is the textbook "Sash sweeper finds
+	// a free turn" / "WP setup-into-sweep" line — without the bonus
+	// the AI keeps trading hits and wastes the protection.
+	if (anyMeaningful && inSetupWindow(ctx)) {
+		score += 18;
+		// Speed-boost specifically wins the game when the setup mon
+		// is slower than the foe (or about to faint to a faster hit).
+		// The classic example is a Weakness Policy holder picking
+		// Dragon Dance / Shift Gear / Quiver Dance over Sword Dance —
+		// after the WP trigger we're +2/+2/+2 and outspeed everything
+		// in range. The extra +10 makes Speed setup decisively win
+		// over pure offensive boosts when both are on the table.
+		if (boostsSpeed && !ctx.weOutspeed) score += 10;
+	}
 	return score;
+}
+
+/**
+ * Heuristic: true when the attacker is essentially guaranteed to live
+ * through one more incoming hit this turn, even if the foe outspeeds.
+ * Used to gate setup-window bonuses (Sword Dance, Calm Mind, ...).
+ *
+ * Conditions:
+ *
+ * - Focus Sash at ≥99% HP — Sash blocks any single-hit KO from full.
+ * - Sturdy at ≥99% HP — same guarantee.
+ *
+ * Multiscale / Shadow Shield aren't included here because they only
+ * halve damage rather than block KOs; the damage calc already accounts
+ * for their multiplier when scoring attacking moves.
+ *
+ * @param ctx Move evaluation context.
+ * @returns true if the attacker is locked in to surviving the turn.
+ */
+function hasGuaranteedSurvivalThisTurn(ctx: MoveEvalContext): boolean {
+	const a = ctx.attacker;
+	const hpf = a.hpFraction ?? 1;
+	if (hpf < 0.99) return false;
+	const item = toID(a.item);
+	const ability = toID(a.ability);
+	if (item === "focussash") return true;
+	if (ability === "sturdy") return true;
+	return false;
+}
+
+/**
+ * True iff the given Pokemon is currently sitting on at least one
+ * negative stat-stage boost. Used as a coarse proxy for Lash Out's
+ * "stat lowered THIS turn" trigger — perfect tracking would need
+ * per-turn boost-deltas; this catches the common case (Intimidate
+ * switch-in, Sticky Web, foe Snarl/Charm) and only over-scores when
+ * the negative stage has been hanging around for multiple turns.
+ *
+ * @param mon The tracked Pokemon snapshot to inspect.
+ * @returns true when any boost stage in `mon.boosts` is below zero.
+ */
+function hasActiveNegativeBoost(mon: TrackedPokemon): boolean {
+	for (const v of Object.values(mon.boosts)) {
+		if (typeof v === "number" && v < 0) return true;
+	}
+	return false;
+}
+
+/**
+ * True when the attacker is in a "setup window" — i.e. it has a
+ * resource that will plausibly keep it on the field for at least one
+ * more turn even into bad damage. This generalises the original
+ * Sash / Sturdy "guaranteed survival" idea to also cover Weakness
+ * Policy bait scenarios and Unburden pre-activation.
+ *
+ * Used by {@link scoreBoostMove} to lift setup moves and by
+ * {@link hazardSetValue} to lift hazard sets (those are the two moves
+ * that *want* to fire on a turn-of-survival).
+ *
+ * @param ctx Move-eval context (attacker, defender, tracker).
+ * @returns true when the attacker should be treated as "definitely
+ *   here next turn", false otherwise.
+ */
+function inSetupWindow(ctx: MoveEvalContext): boolean {
+	if (hasGuaranteedSurvivalThisTurn(ctx)) return true;
+	const a = ctx.attacker;
+	const hpf = a.hpFraction ?? 1;
+	const item = toID(a.item);
+	const ability = toID(a.ability);
+	// Weakness Policy bait: holder lives at ≥60% HP and the foe has a
+	// revealed SE move. The WP trigger arrives next turn, granting +2
+	// Atk / +2 SpA — exactly the conditions that turn a Dragon Dance
+	// from "I hope" into "I'm sweeping".
+	if (item === "weaknesspolicy" && hpf >= 0.6) {
+		for (const moveId of ctx.defender.revealedMoves) {
+			const move = Dex.moves.get(moveId);
+			if (!move?.exists || move.category === "Status") continue;
+			let eff = 0;
+			for (const t of a.types) eff += Dex.getEffectiveness(move.type, t);
+			if (eff > 0) return true;
+		}
+	}
+	// Unburden holder still carrying a one-shot consumable. When that
+	// fires (Sash, Booster Energy, Seed, pinch berry, Sitrus, Lum) we
+	// suddenly double our Speed — the same "set up now and sweep next
+	// turn" plan as Weakness Policy.
+	if (ability === "unburden") {
+		const oneShotItems = new Set([
+			"focussash", "boosterenergy",
+			"grassyseed", "electricseed", "mistyseed", "psychicseed",
+			"salacberry", "liechiberry", "petayaberry",
+			"ganlonberry", "apicotberry", "starfberry",
+			"sitrusberry", "lumberry",
+		]);
+		if (oneShotItems.has(item)) return true;
+	}
+	return false;
 }
 
 /**
@@ -470,24 +670,52 @@ function scoreDebuffMove(move: Move, ctx: MoveEvalContext): number {
 }
 
 function scoreStatusInfliction(status: string, ctx: MoveEvalContext): number {
-	const { defender } = ctx;
+	const { defender, attacker, tracker } = ctx;
 	if (defender.status) return -10; // Already statused.
+	// "Stall combo" detection: status with a follow-up plan (Protect to
+	// burn the timer, Recover/Roost to negate the residual damage
+	// trade, a Defensive boost to outlast). When we have one of those
+	// in our revealed move set, the status is more valuable because
+	// we can capitalise on it next turn instead of letting the foe
+	// switch out cleanly.
+	const myMoves = attacker.revealedMoves;
+	const hasProtect =
+		myMoves.has("protect") || myMoves.has("kingsshield") ||
+		myMoves.has("spikyshield") || myMoves.has("banefulbunker") ||
+		myMoves.has("silktrap") || myMoves.has("burningbulwark");
+	const hasRecovery =
+		myMoves.has("recover") || myMoves.has("roost") ||
+		myMoves.has("softboiled") || myMoves.has("slackoff") ||
+		myMoves.has("milkdrink") || myMoves.has("synthesis") ||
+		myMoves.has("moonlight") || myMoves.has("morningsun") ||
+		myMoves.has("shoreup");
+	const hasDefBoost =
+		myMoves.has("irondefense") || myMoves.has("amnesia") ||
+		myMoves.has("cosmicpower") || myMoves.has("acidarmor") ||
+		myMoves.has("calmmind") || myMoves.has("bulkup");
+	const stallComboBonus = (hasProtect ? 4 : 0) + (hasRecovery ? 4 : 0) + (hasDefBoost ? 3 : 0);
 	switch (status) {
 	case "tox":
 	case "psn": {
 		if (defender.types.includes("Steel") || defender.types.includes("Poison")) return -20;
-		return 16;
+		// Misty Terrain blocks all major statuses on grounded foes;
+		// don't waste a turn trying.
+		if (tracker.field.terrain === "mistyterrain") return -10;
+		return 16 + stallComboBonus;
 	}
 	case "brn": {
 		if (defender.types.includes("Fire")) return -20;
-		return 14;
+		if (tracker.field.terrain === "mistyterrain") return -10;
+		return 14 + stallComboBonus;
 	}
 	case "par": {
 		if (defender.types.includes("Electric") || defender.types.includes("Ground")) return -20;
-		return ctx.weOutspeed ? 6 : 14;
+		if (tracker.field.terrain === "electricterrain" || tracker.field.terrain === "mistyterrain") return -10;
+		return (ctx.weOutspeed ? 6 : 14) + stallComboBonus;
 	}
 	case "slp": {
-		return 18;
+		if (tracker.field.terrain === "electricterrain" || tracker.field.terrain === "mistyterrain") return -10;
+		return 18 + stallComboBonus;
 	}
 	case "frz": return 6; // Rare.
 	}
@@ -688,13 +916,43 @@ function scoreBatonPass(ctx: MoveEvalContext): number {
 }
 
 function hazardSetValue(ctx: MoveEvalContext, hazard: string): number {
-	const { tracker, foeSide } = ctx;
+	const { tracker, foeSide, attacker } = ctx;
 	const remainingFoes = tracker.getTeam(foeSide)
 		.filter(m => !m.fainted)
 		.length;
 	if (remainingFoes <= 1) return -5;
-	let value = 6 * remainingFoes;
-	if (hazard === "stealthrock") value = 8 * remainingFoes;
+	// Per-hazard base value, sized to reflect strategic worth across
+	// the remaining foe team:
+	//   - Sticky Web: -1 Spe to every grounded switch-in (massive tempo).
+	//   - Stealth Rock: universal chip, fires on every switch incl.
+	//     Heavy-Duty Boots-less Flying / Levitate / 4× SR-weak.
+	//   - Toxic Spikes: stacking poison damage on grounded non-Poison.
+	//   - Spikes: scales by layer, slowest payoff.
+	let perFoe: number;
+	switch (hazard) {
+	case "stickyweb": perFoe = 10; break;
+	case "stealthrock": perFoe = 8; break;
+	case "toxicspikes": perFoe = 7; break;
+	default: perFoe = 6; break;
+	}
+	let value = perFoe * remainingFoes;
+	// Setup-window bonus: a Sturdy / Focus Sash user at full HP is
+	// virtually guaranteed to live this turn, so the hazard set is
+	// effectively free regardless of how the matchup looks otherwise.
+	// We also lift hazards inside the wider setup window (WP bait,
+	// Unburden pre-activation) since those mons are sticking around.
+	if (inSetupWindow(ctx)) value += 12;
+	// "Suicide hazard" play: when the active mon is going to faint
+	// regardless of what it does this turn (e.g. faster foe + foe's
+	// best move OHKOs us), a hazard set is a free farewell present to
+	// the rest of the team. Previously we *penalised* low HP here,
+	// which is exactly backwards: a Sturdy/Sash that's already broken
+	// is still going to land its move before falling, and the foe
+	// would have killed us with a damaging move either way. So we
+	// lift hazards modestly when the mon is doomed but still able to
+	// act this turn, instead of subtracting points.
+	const hpf = attacker.hpFraction ?? 1;
+	if (hpf < 0.25 && hpf > 0) value += 6;
 	return value;
 }
 

--- a/sim/tools/strategic-ai/mechanics/MoveEvaluator.ts
+++ b/sim/tools/strategic-ai/mechanics/MoveEvaluator.ts
@@ -421,7 +421,12 @@ function evaluateStatus(
 	// and with hazards on the foe side (any forced switch eats chip).
 	if (moveId === "yawn") {
 		if (defender.status) return { moveId, score: -10, rationale: "yawnRedundant" };
-		if (tracker.field.terrain === "electricterrain" || tracker.field.terrain === "mistyterrain") {
+		// Electric/Misty Terrain only block sleep on *grounded* targets;
+		// an airborne / Levitate foe can still be put to sleep.
+		const yawnBlockedByTerrain =
+			(tracker.field.terrain === "electricterrain" || tracker.field.terrain === "mistyterrain") &&
+			tracker.isPokemonGrounded(defender);
+		if (yawnBlockedByTerrain) {
 			return { moveId, score: -10, rationale: "yawnTerrainBlocked" };
 		}
 		if (attacker.volatiles.has("yawn") || defender.volatiles.has("yawn")) {
@@ -694,27 +699,32 @@ function scoreStatusInfliction(status: string, ctx: MoveEvalContext): number {
 		myMoves.has("cosmicpower") || myMoves.has("acidarmor") ||
 		myMoves.has("calmmind") || myMoves.has("bulkup");
 	const stallComboBonus = (hasProtect ? 4 : 0) + (hasRecovery ? 4 : 0) + (hasDefBoost ? 3 : 0);
+	// Electric/Misty Terrain only block status moves on *grounded*
+	// targets — an airborne / Levitate foe is still a legal target.
+	const grounded = tracker.isPokemonGrounded(defender);
+	const mistyBlocks = grounded && tracker.field.terrain === "mistyterrain";
+	const electricBlocks = grounded && tracker.field.terrain === "electricterrain";
 	switch (status) {
 	case "tox":
 	case "psn": {
 		if (defender.types.includes("Steel") || defender.types.includes("Poison")) return -20;
 		// Misty Terrain blocks all major statuses on grounded foes;
 		// don't waste a turn trying.
-		if (tracker.field.terrain === "mistyterrain") return -10;
+		if (mistyBlocks) return -10;
 		return 16 + stallComboBonus;
 	}
 	case "brn": {
 		if (defender.types.includes("Fire")) return -20;
-		if (tracker.field.terrain === "mistyterrain") return -10;
+		if (mistyBlocks) return -10;
 		return 14 + stallComboBonus;
 	}
 	case "par": {
 		if (defender.types.includes("Electric") || defender.types.includes("Ground")) return -20;
-		if (tracker.field.terrain === "electricterrain" || tracker.field.terrain === "mistyterrain") return -10;
+		if (electricBlocks || mistyBlocks) return -10;
 		return (ctx.weOutspeed ? 6 : 14) + stallComboBonus;
 	}
 	case "slp": {
-		if (tracker.field.terrain === "electricterrain" || tracker.field.terrain === "mistyterrain") return -10;
+		if (electricBlocks || mistyBlocks) return -10;
 		return 18 + stallComboBonus;
 	}
 	case "frz": return 6; // Rare.
@@ -751,10 +761,13 @@ function evaluateCounterMove(
 		moveId === "mirrorcoat" ? "Special" : "Any";
 	const foeLast = defender.lastMove ? Dex.moves.get(defender.lastMove) : null;
 	const foeLastCategory = foeLast?.category;
-	// Outspeeding means we go before the foe can hit us this turn, and
-	// counters reflect "damage taken this turn" — so outspeeding makes
-	// them whiff. The move is best when we're slower.
-	const slower = !ctx.weOutspeed;
+	// Counter and Mirror Coat have -5 priority, so they *always* move
+	// after the foe regardless of Speed — meaning they reflect "damage
+	// taken this turn" even when we outspeed. Only Metal Burst sits at
+	// +0 priority and genuinely whiffs when we move first; for it the
+	// move is best when we're the slower mon.
+	const slower = moveId === "counter" || moveId === "mirrorcoat" ?
+		true : !ctx.weOutspeed;
 	let score: number;
 	let rationale = moveId;
 	const matches =
@@ -789,17 +802,18 @@ function evaluateCounterMove(
  * about to use an attacking move on the same turn. We don't have a
  * perfect predictor, but two signals are usually decisive:
  *
- * - Foe is **choice-locked** into a damaging move → Sucker Punch
- *   is guaranteed to fire; treat it as the best-case priority KO.
- * - Foe **just used** a status / setup / pivot move → Sucker Punch
- *   has a high probability of failing this turn; large negative
- *   score so the AI prefers literally any other move.
- * - Otherwise: small positive baseline (mostly damage), routed back
- *   through the normal damage path so STAB / boosts / items still
- *   register.
+ * - Foe **just used** a status / setup / pivot move (and isn't
+ *   choice-locked) → Sucker Punch has a high probability of failing
+ *   this turn; large negative score so the AI prefers any other move.
+ * - Otherwise (including the foe being **choice-locked** into a
+ *   damaging move, where Sucker Punch is almost guaranteed to fire):
+ *   fall through to the normal damage path. That scores the move on
+ *   its actual damage — so a weak / non-STAB Sucker Punch isn't
+ *   mistaken for a real KO — while STAB / boosts / items and the
+ *   priority-KO bonus still register.
  *
  * Returns `null` to fall through to the default damage path when no
- * specific signal applies.
+ * specific failure signal applies.
  *
  * @param move The Sucker Punch move definition.
  * @param ctx The move evaluation context.
@@ -817,17 +831,12 @@ function evaluateSuckerPunch(
 		// auto-fails. Give it a hard negative score.
 		return { moveId: toID(move.id), score: -15, rationale: "suckerpunchFail" };
 	}
-	if (defender.choiceLocked && last?.exists && last.category !== "Status") {
-		// Locked into an attack → almost-guaranteed fire. Layer on the
-		// priority-KO baseline; the caller's damage path can't reach
-		// this branch but we still pay for the BP via a synthesised
-		// score (priority KO = 30 in our scale).
-		return {
-			moveId: toID(move.id),
-			score: 35,
-			rationale: "suckerpunchLockedKO",
-		};
-	}
+	// Otherwise (incl. the foe being choice-locked into an attack, where
+	// Sucker Punch is almost guaranteed to fire) fall through to the
+	// normal damage path. That scores the move on its *actual* damage —
+	// so a weak / non-STAB Sucker Punch isn't mistaken for a real KO —
+	// and already layers on the priority-KO bonus when the hit is
+	// genuinely threatening.
 	return null;
 }
 
@@ -865,11 +874,19 @@ function scoreDestinyBond(ctx: MoveEvalContext): number {
 	const { attacker } = ctx;
 	if (attacker.volatiles.has("destinybond")) return -25;
 	const myHp = attacker.hpFraction ?? 1;
-	const foeFaster = !ctx.weOutspeed;
-	// Critical HP + foe outspeeds + foe is a likely KO threat — trade.
-	if (myHp < 0.25 && foeFaster) return 55;
-	if (myHp < 0.4 && foeFaster) return 18;
-	// Healthy: DB is wasted turn (foe just keeps not attacking).
+	// Destiny Bond only forces a trade if the bond is *up* at the moment
+	// we faint. Destiny Bond itself has +0 priority, so when the foe
+	// outspeeds and can KO us this turn we faint *before* the bond ever
+	// resolves and the move whiffs. The reliable desperation line is the
+	// opposite of what it looks like: we want to move first, set the
+	// bond, and let the foe's KO this turn drag them down with us.
+	const weMoveFirst = ctx.weOutspeed;
+	// Critical HP + we get the bond up before the incoming KO — the
+	// textbook "low HP, take them with me" trade.
+	if (myHp < 0.25 && weMoveFirst) return 55;
+	if (myHp < 0.4 && weMoveFirst) return 18;
+	// Healthy (wasted turn), or we're slower (bond likely whiffs to a
+	// faster KO before it can resolve).
 	return -10;
 }
 

--- a/sim/tools/strategic-ai/mechanics/MoveEvaluator.ts
+++ b/sim/tools/strategic-ai/mechanics/MoveEvaluator.ts
@@ -81,6 +81,16 @@ export function evaluateMove(
 	if (moveId === "counter" || moveId === "mirrorcoat" || moveId === "metalburst") {
 		return evaluateCounterMove(m, moveId, ctx);
 	}
+	// Sucker Punch: priority physical that only fires if the foe is
+	// about to use an attacking move this turn. The normal damage path
+	// still scores its BP correctly, but we need an extra branch to
+	// avoid spamming it into setup/status mons (where it auto-fails
+	// and we lose the turn) and to *reward* it when we can predict
+	// the foe's reply will be a damaging move.
+	if (moveId === "suckerpunch") {
+		const evaluation = evaluateSuckerPunch(m, ctx);
+		if (evaluation) return evaluation;
+	}
 	if (m.category === "Status") {
 		return evaluateStatus(m, moveId, ctx);
 	}
@@ -105,16 +115,53 @@ export function evaluateMove(
 		score += 25 * calc.koProbability;
 		rationale = "likelyKO";
 	}
-	// Priority bonus: when the foe outspeeds and is in KO range, priority
-	// effectively converts a possible KO into a guaranteed one.
-	if (m.priority > 0 && !ctx.weOutspeed) {
+	// Priority bonus. Showdown priority is in [-7, +5]; almost every
+	// positive-priority move we care about sits in +1..+4 (Quick Attack,
+	// Bullet Punch, Sucker Punch, Mach Punch, Aqua Jet, Ice Shard,
+	// Extreme Speed, Fake Out, First Impression). Score them by what
+	// they actually buy us:
+	//
+	//   - Guaranteed KO when the foe would have outsped us (the big win).
+	//   - Insurance KO when our own HP is low enough that the foe's hit
+	//     would faint us before a slower move resolved.
+	//   - Chip damage that puts the foe in KO range for the bench (so
+	//     the next mon can finish them off cleanly).
+	//   - Even at full HP / outspeeding, a small baseline so the AI
+	//     doesn't ignore priority entirely on neutral matchups.
+	if (m.priority > 0) {
 		const remaining = (defender.hpFraction ?? 1) * maxHp;
-		if (calc.avgDamage >= remaining * 0.9) {
-			score += 25;
+		const myHp = attacker.hpFraction ?? 1;
+		const wouldKO = calc.avgDamage >= remaining * 0.9 || calc.koProbability > 0.5;
+		const stackedPriority = m.priority >= 2 ? 1.5 : 1;
+		if (!ctx.weOutspeed) {
+			if (wouldKO) {
+				score += 30 * stackedPriority;
+				rationale = "priorityKO";
+			} else if (myHp < 0.4) {
+				// We're slower AND fragile — a guaranteed hit is huge
+				// even if it doesn't KO, because we may not get another
+				// turn at all.
+				score += 14 * stackedPriority;
+				rationale = "priorityInsurance";
+			} else {
+				score += 6 * stackedPriority;
+			}
+		} else if (wouldKO) {
+			// Outspeeding + KO is the same outcome as a slower KO, but
+			// priority still helps if e.g. the foe is +Spe boosted or
+			// Scarfed and we mis-counted.
+			score += 8 * stackedPriority;
 			rationale = "priorityKO";
 		} else {
-			score += 5;
+			score += 3 * stackedPriority;
 		}
+		// "Chip into KO range for next mon": even if this hit doesn't
+		// KO and we're not in danger, weakening a foe so a bench
+		// sweeper finishes it next turn is real value.
+		const chipBringsKORange =
+			!wouldKO &&
+			(calc.avgDamage / Math.max(1, remaining)) >= 0.35;
+		if (chipBringsKORange) score += 4;
 	}
 	if (m.priority < 0) {
 		score -= 5;
@@ -504,6 +551,56 @@ function evaluateCounterMove(
 	// Health gate: must survive a hit to retaliate.
 	if ((attacker.hpFraction ?? 1) < 0.25) score -= 20;
 	return { moveId, score, damage: undefined, rationale };
+}
+
+/**
+ * Score Sucker Punch.
+ *
+ * The standard damage path already returns the BP-70 estimate, but it
+ * doesn't know that Sucker Punch *fails outright* unless the foe is
+ * about to use an attacking move on the same turn. We don't have a
+ * perfect predictor, but two signals are usually decisive:
+ *
+ * - Foe is **choice-locked** into a damaging move → Sucker Punch
+ *   is guaranteed to fire; treat it as the best-case priority KO.
+ * - Foe **just used** a status / setup / pivot move → Sucker Punch
+ *   has a high probability of failing this turn; large negative
+ *   score so the AI prefers literally any other move.
+ * - Otherwise: small positive baseline (mostly damage), routed back
+ *   through the normal damage path so STAB / boosts / items still
+ *   register.
+ *
+ * Returns `null` to fall through to the default damage path when no
+ * specific signal applies.
+ *
+ * @param move The Sucker Punch move definition.
+ * @param ctx The move evaluation context.
+ * @returns A `MoveEvaluation` when we have an opinion, otherwise null.
+ */
+function evaluateSuckerPunch(
+	move: Move,
+	ctx: MoveEvalContext
+): MoveEvaluation | null {
+	const { defender } = ctx;
+	const last = defender.lastMove ? Dex.moves.get(defender.lastMove) : null;
+	const lastWasStatus = last?.exists && last.category === "Status";
+	if (lastWasStatus && !defender.choiceLocked) {
+		// Foe likely sets up / heals again this turn → Sucker Punch
+		// auto-fails. Give it a hard negative score.
+		return { moveId: toID(move.id), score: -15, rationale: "suckerpunchFail" };
+	}
+	if (defender.choiceLocked && last?.exists && last.category !== "Status") {
+		// Locked into an attack → almost-guaranteed fire. Layer on the
+		// priority-KO baseline; the caller's damage path can't reach
+		// this branch but we still pay for the BP via a synthesised
+		// score (priority KO = 30 in our scale).
+		return {
+			moveId: toID(move.id),
+			score: 35,
+			rationale: "suckerpunchLockedKO",
+		};
+	}
+	return null;
 }
 
 /**

--- a/sim/tools/strategic-ai/mechanics/SwitchEvaluator.ts
+++ b/sim/tools/strategic-ai/mechanics/SwitchEvaluator.ts
@@ -134,6 +134,26 @@ export function evaluateMatchup(
 	// because it works from the *current* tracker state.
 	score += entrySynergyBonus(mon, foe, tracker);
 
+	// Survivability gate: a switch-in that will be OHKO'd by the foe's
+	// best plausible attack is a sacrifice, not a switch. The linear
+	// `foeDealFraction * 30` penalty above can be overcome by entry
+	// synergies + speed bonuses, which is how we used to swap into a
+	// 4×-weak teammate to "activate Booster Energy" and immediately
+	// faint. Stack an explicit non-linear penalty whenever the foe's
+	// best move is a likely OHKO so that path is closed off — unless
+	// the candidate brings something that compensates (priority KO,
+	// massive speed control, etc., which downstream code can still
+	// add). We also count residual hazard damage toward the OHKO
+	// threshold because the hazard tick happens before the foe's hit.
+	const survivabilityHit =
+		(foeBest?.avgDamage ?? 0) / Math.max(1, myMaxHp) +
+		hazardFraction;
+	if (survivabilityHit >= 0.95) {
+		score -= 35;
+	} else if (survivabilityHit >= 0.7) {
+		score -= 15;
+	}
+
 	return { score, weDealFraction, foeDealFraction, speedDelta, hazardFraction };
 }
 
@@ -166,6 +186,7 @@ function entrySynergyBonus(
 	const item = toID(mon.item);
 	const ability = toID(mon.ability);
 	const terrain = tracker.field.terrain;
+	const weather = tracker.field.weather;
 
 	// Terrain-seed entry boost. The seed is consumed on entry and grants
 	// +1 Def (Grassy/Electric) or +1 SpDef (Misty/Psychic) for the stay.
@@ -207,8 +228,48 @@ function entrySynergyBonus(
 		hadronengine: "electricterrain",
 	};
 	const broughtWeather = weatherFromAbility[ability];
-	if (broughtWeather && broughtWeather !== tracker.field.weather && broughtWeather !== tracker.field.terrain) {
+	if (broughtWeather && broughtWeather !== weather && broughtWeather !== terrain) {
 		bonus += 4;
+	}
+
+	// Weather-speed synergy (Chlorophyll / Swift Swim / Sand Rush /
+	// Slush Rush): when the matching weather is already active and the
+	// candidate's Speed boost would let it outspeed the current foe,
+	// reward heavily. We avoid double-counting with `scaledSpeed`'s
+	// speed-delta — this bonus targets the *decision* layer (the AI
+	// often refuses to swap a slow mon in even when the weather makes
+	// it the fastest thing on the field).
+	const weatherSpeedAbility: Record<string, (w: string) => boolean> = {
+		swiftswim: w => w === "raindance" || w === "primordialsea",
+		chlorophyll: w => w === "sunnyday" || w === "desolateland",
+		sandrush: w => w === "sandstorm",
+		slushrush: w => w === "snow" || w === "snowscape" || w === "hail",
+	};
+	if (weatherSpeedAbility[ability]?.(weather)) {
+		const baseSpe = mon.stats?.spe ?? 0;
+		const foeSpe = foe.stats?.spe ?? 0;
+		// Pre-bonus we'd have been slower; with the 2× we'd outspeed →
+		// massive tempo swing.
+		if (baseSpe <= foeSpe && baseSpe * 2 > foeSpe) bonus += 12;
+		else bonus += 4;
+	}
+
+	// Booster Energy on a Paradox mon switching into a field that
+	// won't activate the ability naturally (no sun for Protosynthesis,
+	// no Electric Terrain for Quark Drive). The held Booster Energy
+	// triggers on entry instead, granting +30%/+50% to the highest
+	// stat for the duration of the stay.
+	if (item === "boosterenergy") {
+		const isProto = ability === "protosynthesis";
+		const isQuark = ability === "quarkdrive";
+		const protoFromField = weather === "sunnyday" || weather === "desolateland";
+		const quarkFromField = terrain === "electricterrain";
+		// Only reward Booster Energy when the field wouldn't have
+		// already activated the ability — otherwise the item is just
+		// a wasted slot.
+		if ((isProto && !protoFromField) || (isQuark && !quarkFromField)) {
+			bonus += 10;
+		}
 	}
 
 	return bonus;
@@ -375,10 +436,67 @@ function scaledSpeed(mon: TrackedPokemon, tailwind: boolean, weather: string): n
 		(weather === "snow" || weather === "snowscape" || weather === "hail")) {
 		spe *= 2;
 	}
+	// Paradox speed boost when Protosynthesis/Quark Drive picks Speed
+	// as the highest stat: this is the +50% Booster-Energy / sun /
+	// electric-terrain bonus (`paradoxBoostedStat` returns `spe` only
+	// in that case).
+	if (paradoxSpeedActive(mon, weather)) spe = Math.floor(spe * 1.5);
 	if (tailwind) spe *= 2;
 	if (mon.status === "par" && ability !== "quickfeet") spe = Math.floor(spe / 2);
 	if (ability === "quickfeet" && mon.status) spe = Math.floor(spe * 1.5);
 	return spe;
+}
+
+/**
+ * Check whether the mon's Protosynthesis / Quark Drive boost is
+ * currently picking Speed. We mirror the activation logic in
+ * `DamageCalc.paradoxBoostedStat`: ability + (matching field or
+ * Booster Energy in hand or a recorded `*spe` volatile).
+ *
+ * @param mon Tracked Pokemon snapshot.
+ * @param weather Active weather id.
+ * @returns true if the Speed multiplier applies.
+ */
+function paradoxSpeedActive(mon: TrackedPokemon, weather: string): boolean {
+	const ability = toID(mon.ability);
+	if (ability !== "protosynthesis" && ability !== "quarkdrive") return false;
+	for (const v of mon.volatiles) {
+		if (v === "protosynthesisspe" || v === "quarkdrivespe") return true;
+	}
+	const item = toID(mon.item);
+	const hasBooster = item === "boosterenergy";
+	const sun = weather === "sunnyday" || weather === "desolateland";
+	const isProto = ability === "protosynthesis";
+	// Without an explicit volatile or stat block we don't know which
+	// stat the ability picks. Approximate by checking whether Speed is
+	// the species' highest base stat (the most common Paradox sweeper
+	// configuration). Conservative: returns false when in doubt.
+	if (!(isProto ? sun || hasBooster : hasBooster)) return false;
+	const stats = mon.stats;
+	if (!stats) {
+		// Fall back to a species-base-stat lookup; the Dex import is
+		// available at the top of the file.
+		const species = Dex.species.get(toID(mon.species));
+		if (!species?.exists || !species.baseStats) return false;
+		const { atk, def, spa, spd, spe } = species.baseStats;
+		return spe >= Math.max(atk, def, spa, spd);
+	}
+	const candidates: [keyof typeof stats, number][] = [
+		["atk", stats.atk ?? 0],
+		["def", stats.def ?? 0],
+		["spa", stats.spa ?? 0],
+		["spd", stats.spd ?? 0],
+		["spe", stats.spe ?? 0],
+	];
+	let best: keyof typeof stats = "atk";
+	let bestVal = -Infinity;
+	for (const [k, v] of candidates) {
+		if (v > bestVal) {
+			bestVal = v;
+			best = k;
+		}
+	}
+	return best === "spe";
 }
 
 function approximateSpeed(mon: TrackedPokemon): number {

--- a/sim/tools/strategic-ai/mechanics/SwitchEvaluator.ts
+++ b/sim/tools/strategic-ai/mechanics/SwitchEvaluator.ts
@@ -272,7 +272,135 @@ function entrySynergyBonus(
 		}
 	}
 
+	// Absorb / punish ability switch-in: if the foe has revealed (or
+	// just used) a move that our ability nullifies or feeds on, this
+	// is a free turn — often a heal, a stat boost, or a flat
+	// nullification. The damage calc already returns 0 for the
+	// nullified hit, so `foeDealFraction` reflects the *avoided*
+	// damage; this bonus reflects the *positive* upside (the heal /
+	// boost / continued pressure from the absorb).
+	bonus += absorbAbilityBonus(mon, foe);
+
+	// Weakness Policy "bait" recognition: the holder *wants* a SE
+	// physical or special hit to trigger +2 Atk / +2 SpA. If the foe's
+	// best plausible move is SE on us, the candidate trades one hit
+	// for a free double-dance. Survivability gating happens upstream
+	// in `evaluateMatchup` so we don't recommend WP-baiting on a 4×
+	// weakness OHKO.
+	if (item === "weaknesspolicy") {
+		const seBait = anyRevealedFoeMoveIsSuperEffective(foe, mon);
+		if (seBait) bonus += 10;
+	}
+
 	return bonus;
+}
+
+/**
+ * Bonus a candidate earns for having an ability that turns one of the
+ * foe's *revealed* moves into a "do nothing / give us something"
+ * outcome.
+ *
+ * Where the damage calc already zeros out the matchup's
+ * `foeDealFraction` (Flash Fire blocking Fire, Water Absorb / Volt
+ * Absorb blocking their type, Levitate ignoring Ground, etc.), this
+ * bonus represents the *additional* value beyond just "didn't take
+ * damage": a heal, a +1 stat stage, or sustained type pressure.
+ *
+ * The check requires the foe to have actually revealed (or last-used)
+ * a matching move — we don't switch a Flash Fire user into a foe with
+ * no Fire move on its known list just because Charizard *might* have
+ * one. Revealed-only avoids cheating with hidden moves while still
+ * acting on the simulator-emitted signal.
+ *
+ * @param mon Candidate switch-in.
+ * @param foe Foe's active mon (with its revealed move set).
+ * @returns Synergy bonus, capped at +20 to keep matchup math sane.
+ */
+function absorbAbilityBonus(
+	mon: TrackedPokemon,
+	foe: TrackedPokemon
+): number {
+	const ability = toID(mon.ability);
+	if (!ability) return 0;
+	const known = new Set<string>(foe.revealedMoves);
+	if (foe.lastMove) known.add(foe.lastMove);
+	if (known.size === 0) return 0;
+	let bonus = 0;
+	for (const moveId of known) {
+		const move = Dex.moves.get(moveId);
+		if (!move?.exists || move.category === "Status") continue;
+		const moveType = move.type;
+		// Type immunities that grant a flat-out free turn.
+		if (
+			(ability === "flashfire" && moveType === "Fire") ||
+			(ability === "wellbakedbody" && moveType === "Fire") ||
+			(ability === "voltabsorb" && moveType === "Electric") ||
+			(ability === "lightningrod" && moveType === "Electric") ||
+			(ability === "motordrive" && moveType === "Electric") ||
+			(ability === "waterabsorb" && moveType === "Water") ||
+			(ability === "stormdrain" && moveType === "Water") ||
+			(ability === "dryskin" && moveType === "Water") ||
+			(ability === "sapsipper" && moveType === "Grass") ||
+			(ability === "eartheater" && moveType === "Ground") ||
+			(ability === "levitate" && moveType === "Ground") ||
+			(ability === "windrider" && (move.flags?.wind || moveType === "Flying"))
+		) {
+			// Heal / boost abilities are slightly better than pure
+			// nullifications because they also tip the matchup in our
+			// favour for next turn.
+			const boostAbilities = new Set([
+				"flashfire", "wellbakedbody", "stormdrain", "lightningrod",
+				"motordrive", "sapsipper", "windrider",
+			]);
+			const healAbilities = new Set(["voltabsorb", "waterabsorb", "dryskin", "eartheater"]);
+			if (boostAbilities.has(ability)) bonus = Math.max(bonus, 20);
+			else if (healAbilities.has(ability)) bonus = Math.max(bonus, 18);
+			else bonus = Math.max(bonus, 14);
+			continue;
+		}
+		// Flag-based immunities.
+		if (ability === "bulletproof" && move.flags?.bullet) {
+			bonus = Math.max(bonus, 16);
+			continue;
+		}
+		if (ability === "soundproof" && move.flags?.sound) {
+			bonus = Math.max(bonus, 14);
+			continue;
+		}
+		// Purifying Salt: not an immunity, but halves Ghost damage and
+		// makes us status-proof. A modest bonus when the foe has a
+		// Ghost move revealed.
+		if (ability === "purifyingsalt" && moveType === "Ghost") {
+			bonus = Math.max(bonus, 8);
+		}
+	}
+	return bonus;
+}
+
+/**
+ * True if any of the foe's revealed moves would be super-effective on
+ * `mon` (used to detect Weakness Policy / Beast Boost / Anger Point
+ * "bait" scenarios).
+ *
+ * @param foe Foe with revealedMoves.
+ * @param mon Candidate evaluating the matchup.
+ * @returns true when any revealed move's type is 2× or 4× on `mon`.
+ */
+function anyRevealedFoeMoveIsSuperEffective(
+	foe: TrackedPokemon,
+	mon: TrackedPokemon
+): boolean {
+	if (!foe.revealedMoves.size && !foe.lastMove) return false;
+	const known = new Set<string>(foe.revealedMoves);
+	if (foe.lastMove) known.add(foe.lastMove);
+	for (const moveId of known) {
+		const move = Dex.moves.get(moveId);
+		if (!move?.exists || move.category === "Status") continue;
+		let eff = 0;
+		for (const t of mon.types) eff += Dex.getEffectiveness(move.type, t);
+		if (eff > 0) return true;
+	}
+	return false;
 }
 
 /**
@@ -420,7 +548,26 @@ function computeSpeedDelta(
 	return delta;
 }
 
-function scaledSpeed(mon: TrackedPokemon, tailwind: boolean, weather: string): number {
+/**
+ * Compute the effective Speed of `mon` after weather-speed abilities
+ * (Swift Swim, Chlorophyll, Sand Rush, Slush Rush), Paradox-style
+ * +50% boosts, Choice Scarf, stat-stage modifiers, Tailwind, and
+ * Paralysis. This is the same number {@link evaluateMatchup} uses
+ * when computing speed-tier deltas, and is exported so other engine
+ * layers (emergency-switch checks, `weOutspeed` predicates) can stay
+ * consistent with the switch evaluator.
+ *
+ * @param mon The Pokemon whose effective Speed we want.
+ * @param tailwind Whether the side currently has Tailwind active.
+ * @param weather The current field weather id (`raindance`,
+ *   `sunnyday`, `sandstorm`, `snow`, ...).
+ * @returns Estimated in-battle Speed stat (post-modifiers).
+ */
+export function scaledSpeed(
+	mon: TrackedPokemon,
+	tailwind: boolean,
+	weather: string
+): number {
 	let spe = mon.stats?.spe ?? approximateSpeed(mon);
 	const stage = mon.boosts.spe || 0;
 	if (stage > 0) spe = Math.floor(spe * (2 + stage) / 2);

--- a/sim/tools/strategic-ai/mechanics/SwitchEvaluator.ts
+++ b/sim/tools/strategic-ai/mechanics/SwitchEvaluator.ts
@@ -208,11 +208,25 @@ function entrySynergyBonus(
 		// scale by how physical the foe looks. Pure special attackers
 		// get the floor (the lost Atk is wasted).
 		const physicalLean = foeAtk > foeSpa ? 1 : foeAtk >= foeSpa * 0.85 ? 0.5 : 0.15;
-		// Unaware on the foe ignores our Intimidate drop's offensive
-		// impact, though the stage is still applied; treat that as
-		// neutral.
-		if (toID(foe.ability) === "unaware") bonus += 0;
-		else bonus += 7 * physicalLean;
+		const foeAbil = toID(foe.ability);
+		// Abilities that turn Intimidate against us: Defiant/Competitive
+		// convert the drop into a +2 boost for the foe, Mirror Armor
+		// reflects it back onto our Attack, and Guard Dog raises the
+		// foe's Attack instead. Switching Intimidate in is actively bad.
+		const punishesIntimidate =
+			foeAbil === "defiant" || foeAbil === "competitive" ||
+			foeAbil === "mirrorarmor" || foeAbil === "guarddog";
+		// Abilities that simply ignore the Attack drop. Note: Unaware is
+		// NOT one of these — it only ignores the *opponent's* stat
+		// stages during damage calc, so the foe still attacks with its
+		// own Intimidate-lowered Attack and the matchup bonus stands.
+		const blocksIntimidate =
+			foeAbil === "clearbody" || foeAbil === "whitesmoke" ||
+			foeAbil === "fullmetalbody" || foeAbil === "hypercutter" ||
+			foeAbil === "innerfocus" || foeAbil === "owntempo" ||
+			foeAbil === "oblivious" || foeAbil === "scrappy";
+		if (punishesIntimidate) bonus -= 6 * physicalLean;
+		else if (!blocksIntimidate) bonus += 7 * physicalLean;
 	}
 
 	// Weather setters on entry: a switch-in that brings a *new* weather
@@ -343,7 +357,11 @@ function absorbAbilityBonus(
 			(ability === "sapsipper" && moveType === "Grass") ||
 			(ability === "eartheater" && moveType === "Ground") ||
 			(ability === "levitate" && moveType === "Ground") ||
-			(ability === "windrider" && (move.flags?.wind || moveType === "Flying"))
+			// Wind Rider only grants a free turn against *wind-flagged*
+			// moves (Tailwind, Hurricane, Bleakwind Storm, ...), NOT
+			// every Flying attack — Brave Bird / Air Slash / Acrobatics
+			// hit it normally.
+			(ability === "windrider" && !!move.flags?.wind)
 		) {
 			// Heal / boost abilities are slightly better than pure
 			// nullifications because they also tip the matchup in our
@@ -396,10 +414,52 @@ function anyRevealedFoeMoveIsSuperEffective(
 	for (const moveId of known) {
 		const move = Dex.moves.get(moveId);
 		if (!move?.exists || move.category === "Status") continue;
+		// A move that deals zero damage can't trigger Weakness Policy,
+		// even if the type chart says it's super-effective (Levitate vs
+		// Ground, Flash Fire vs Fire, Air Balloon vs Ground, ...).
+		if (isMoveNeutralizedBy(move, mon)) continue;
 		let eff = 0;
 		for (const t of mon.types) eff += Dex.getEffectiveness(move.type, t);
 		if (eff > 0) return true;
 	}
+	return false;
+}
+
+/**
+ * True when `target` takes no damage from `move` because of a type,
+ * ability, or item immunity — i.e. the hit would deal zero and so
+ * can't proc damage-triggered effects like Weakness Policy.
+ *
+ * @param move The incoming move.
+ * @param target The Pokemon being hit.
+ * @returns true if the move is fully neutralized.
+ */
+function isMoveNeutralizedBy(move: Move, target: TrackedPokemon): boolean {
+	const moveType = move.type;
+	// Type-based immunity (Ground vs Flying, Normal/Fighting vs Ghost, ...).
+	if (!Dex.getImmunity(moveType, target.types)) return true;
+	const ability = toID(target.ability);
+	const item = toID(target.item);
+	// Ability-based type immunities / absorptions.
+	const absorbType: Record<string, string> = {
+		levitate: "Ground",
+		flashfire: "Fire",
+		wellbakedbody: "Fire",
+		voltabsorb: "Electric",
+		lightningrod: "Electric",
+		motordrive: "Electric",
+		waterabsorb: "Water",
+		stormdrain: "Water",
+		dryskin: "Water",
+		sapsipper: "Grass",
+		eartheater: "Ground",
+	};
+	if (absorbType[ability] === moveType) return true;
+	if (ability === "bulletproof" && move.flags?.bullet) return true;
+	if (ability === "soundproof" && move.flags?.sound) return true;
+	if ((ability === "windrider" || ability === "windpower") && move.flags?.wind) return true;
+	// Air Balloon grants a Ground immunity until it pops.
+	if (item === "airballoon" && moveType === "Ground") return true;
 	return false;
 }
 
@@ -430,19 +490,22 @@ export function chooseBestSwitch(
 /**
  * Find the best damaging move `attacker` can throw at `defender`.
  *
- * We pull every revealed damaging move from the attacker's known set,
- * AND additionally consider STAB-type proxies derived from the
- * attacker's species. STAB types are publicly inferable from the
- * species, so this isn't "cheating": the AI just refuses to pretend
- * a Garchomp won't have a Ground STAB until it sees Earthquake.
+ * We pull every revealed damaging move from the attacker's known set.
+ * When we're estimating the *foe's* threat (`useKnownOnly === true`)
+ * the revealed set is only partial, so we additionally consider
+ * STAB-type proxies derived from the foe's species. STAB types are
+ * publicly inferable from the species, so this isn't "cheating": the
+ * AI just refuses to pretend a Garchomp won't have a Ground STAB until
+ * it sees Earthquake. Without this, a foe that has only revealed one
+ * of its two STABs looks artificially safe — so on monotype teams the
+ * AI would happily switch a 4×-weak teammate into an unrevealed hit.
  *
- * Without this, a foe that has only revealed one of its two STABs
- * looks artificially safe — so on monotype teams the AI would happily
- * switch a 4×-weak teammate into an unrevealed coverage hit.
- *
- * When `useKnownOnly` is false (our → foe evaluation) we additionally
- * probe a wider coverage-type shortlist so we estimate our own
- * unrevealed-but-likely move pool optimistically.
+ * For *our* side (`useKnownOnly === false`) the revealed set is seeded
+ * from the battle request and is therefore the complete moveset, so we
+ * use it as-is and only fall back to proxies if it somehow contains no
+ * damaging move. Each proxy is emitted in both Physical and Special
+ * flavours so special-leaning attackers aren't clamped to their unused
+ * Attack stat (the max-damage selection picks whichever hurts more).
  *
  * @param attacker The CalcPokemon snapshot of the attacking side.
  * @param defender The CalcPokemon snapshot of the defending side.
@@ -450,7 +513,7 @@ export function chooseBestSwitch(
  * @param attackerMon TrackedPokemon record for the attacker (move pool).
  * @param defenderMon TrackedPokemon record for the defender (unused, for symmetry).
  * @param useKnownOnly True when we're estimating the foe's threat to us:
- *   skips the wide coverage probe but still includes STAB proxies.
+ *   uses only revealed moves plus species STAB proxies (no coverage probe).
  * @param attackerSideId Tracker side id of the attacker (for screens/Tailwind).
  * @param defenderSideId Tracker side id of the defender (for screens/Tailwind).
  * @returns The highest expected damage roll along with the move id, or `null`
@@ -472,46 +535,58 @@ function bestAttackingDamage(
 		const m = Dex.moves.get(id);
 		if (m && m.category !== "Status" && m.basePower > 0) moves.push(m);
 	}
-	// Always add STAB proxies for the attacker's effective types — but
-	// only ones the attacker doesn't already cover with a revealed move
-	// of the same type. Species typing is public information, so
-	// assuming the mon has at least *one* damaging STAB option is safe
-	// and prevents the AI from over-trusting an incomplete revealed
-	// list. Skipping types we already see avoids double-counting
-	// (revealed Earthquake + imagined "Proxy Ground" → over-estimate).
-	const revealedTypes = new Set(moves.map(m => m.type));
-	const tackleProto = Dex.moves.get("tackle");
-	const seenProxyTypes = new Set<string>();
-	for (const t of attackerMon.types) {
-		if (seenProxyTypes.has(t) || revealedTypes.has(t)) continue;
-		seenProxyTypes.add(t);
-		// Slightly lower BP for the proxy (80) than a real STAB so the
-		// estimate is "the foe probably has *some* attack of this type"
-		// without claiming it's a guaranteed top-tier hit.
-		moves.push({
-			...tackleProto,
-			id: `proxystab${t.toLowerCase()}` as never,
-			name: `Proxy ${t}`,
-			type: t,
-			category: "Physical",
-			basePower: 80,
-			accuracy: 100,
-		});
-	}
-	if (!useKnownOnly) {
-		// Coverage moves: the most-feared off-type move. We probe a
-		// shortlist of common types; the best one wins.
-		for (const t of COMMON_COVERAGE_TYPES) {
-			if (seenProxyTypes.has(t) || revealedTypes.has(t)) continue;
+	const hasRevealedDamage = moves.length > 0;
+	// Whether to synthesise STAB / coverage proxies for unrevealed moves.
+	//
+	// For the *foe* (`useKnownOnly === true`) the revealed set is
+	// partial, so proxies are essential — they stop a foe that's only
+	// shown one of its two STABs from looking artificially safe.
+	//
+	// For *our* side (`useKnownOnly === false`) the revealed set is
+	// seeded from the battle request and is therefore the *complete*
+	// moveset. Imagining extra STAB/coverage moves on top would
+	// overestimate our own output and skew matchup/switching decisions,
+	// so we only fall back to proxies when (defensively) we somehow have
+	// no revealed damaging move to work from.
+	const addProxies = useKnownOnly || !hasRevealedDamage;
+	if (addProxies) {
+		// Skip types already covered by a revealed move to avoid
+		// double-counting (revealed Earthquake + imagined "Proxy
+		// Ground" → over-estimate). Emit BOTH categories per type and
+		// let the max-damage selection below pick whichever side
+		// actually hurts — this avoids clamping a special attacker
+		// (e.g. Magnezone) to its unused Attack stat.
+		const revealedTypes = new Set(moves.map(m => m.type));
+		const tackleProto = Dex.moves.get("tackle");
+		const seenProxyTypes = new Set<string>();
+		const pushProxy = (idPrefix: string, t: string, category: "Physical" | "Special") => {
 			moves.push({
 				...tackleProto,
-				id: `proxycov${t.toLowerCase()}` as never,
-				name: `Proxy ${t}`,
+				id: `${idPrefix}${category.toLowerCase()}${t.toLowerCase()}` as never,
+				name: `Proxy ${category} ${t}`,
 				type: t,
-				category: "Physical",
+				// Slightly lower BP for the proxy (80) than a real STAB
+				// so the estimate is "probably has *some* attack of this
+				// type" without claiming a guaranteed top-tier hit.
+				category,
 				basePower: 80,
 				accuracy: 100,
 			});
+		};
+		for (const t of attackerMon.types) {
+			if (seenProxyTypes.has(t) || revealedTypes.has(t)) continue;
+			seenProxyTypes.add(t);
+			pushProxy("proxystab", t, "Physical");
+			pushProxy("proxystab", t, "Special");
+		}
+		if (!useKnownOnly) {
+			// Coverage moves: the most-feared off-type move. We probe a
+			// shortlist of common types; the best one wins.
+			for (const t of COMMON_COVERAGE_TYPES) {
+				if (seenProxyTypes.has(t) || revealedTypes.has(t)) continue;
+				pushProxy("proxycov", t, "Physical");
+				pushProxy("proxycov", t, "Special");
+			}
 		}
 	}
 	let best: { avgDamage: number, moveId: string } | null = null;
@@ -541,8 +616,9 @@ function computeSpeedDelta(
 	tracker: BattleStateTracker
 ): number {
 	const weather = tracker.field.weather;
-	const mySpe = scaledSpeed(mon, tracker.sides[tracker.mySide].tailwindTurns > 0, weather);
-	const foeSpe = scaledSpeed(foe, tracker.sides[tracker.foeSide].tailwindTurns > 0, weather);
+	const terrain = tracker.field.terrain;
+	const mySpe = scaledSpeed(mon, tracker.sides[tracker.mySide].tailwindTurns > 0, weather, terrain);
+	const foeSpe = scaledSpeed(foe, tracker.sides[tracker.foeSide].tailwindTurns > 0, weather, terrain);
 	let delta = mySpe - foeSpe;
 	if (tracker.field.trickRoom) delta = -delta;
 	return delta;
@@ -561,12 +637,16 @@ function computeSpeedDelta(
  * @param tailwind Whether the side currently has Tailwind active.
  * @param weather The current field weather id (`raindance`,
  *   `sunnyday`, `sandstorm`, `snow`, ...).
+ * @param terrain The current field terrain id (`electricterrain`, ...);
+ *   used so Quark Drive's Speed boost can fire off Electric Terrain set
+ *   by another source, not just Booster Energy. Defaults to none.
  * @returns Estimated in-battle Speed stat (post-modifiers).
  */
 export function scaledSpeed(
 	mon: TrackedPokemon,
 	tailwind: boolean,
-	weather: string
+	weather: string,
+	terrain = ""
 ): number {
 	let spe = mon.stats?.spe ?? approximateSpeed(mon);
 	const stage = mon.boosts.spe || 0;
@@ -587,7 +667,7 @@ export function scaledSpeed(
 	// as the highest stat: this is the +50% Booster-Energy / sun /
 	// electric-terrain bonus (`paradoxBoostedStat` returns `spe` only
 	// in that case).
-	if (paradoxSpeedActive(mon, weather)) spe = Math.floor(spe * 1.5);
+	if (paradoxSpeedActive(mon, weather, terrain)) spe = Math.floor(spe * 1.5);
 	if (tailwind) spe *= 2;
 	if (mon.status === "par" && ability !== "quickfeet") spe = Math.floor(spe / 2);
 	if (ability === "quickfeet" && mon.status) spe = Math.floor(spe * 1.5);
@@ -602,9 +682,11 @@ export function scaledSpeed(
  *
  * @param mon Tracked Pokemon snapshot.
  * @param weather Active weather id.
+ * @param terrain Active terrain id (Quark Drive activates on Electric
+ *   Terrain regardless of who set it).
  * @returns true if the Speed multiplier applies.
  */
-function paradoxSpeedActive(mon: TrackedPokemon, weather: string): boolean {
+function paradoxSpeedActive(mon: TrackedPokemon, weather: string, terrain: string): boolean {
 	const ability = toID(mon.ability);
 	if (ability !== "protosynthesis" && ability !== "quarkdrive") return false;
 	for (const v of mon.volatiles) {
@@ -613,12 +695,13 @@ function paradoxSpeedActive(mon: TrackedPokemon, weather: string): boolean {
 	const item = toID(mon.item);
 	const hasBooster = item === "boosterenergy";
 	const sun = weather === "sunnyday" || weather === "desolateland";
+	const eTerrain = terrain === "electricterrain";
 	const isProto = ability === "protosynthesis";
 	// Without an explicit volatile or stat block we don't know which
 	// stat the ability picks. Approximate by checking whether Speed is
 	// the species' highest base stat (the most common Paradox sweeper
 	// configuration). Conservative: returns false when in doubt.
-	if (!(isProto ? sun || hasBooster : hasBooster)) return false;
+	if (!(isProto ? sun || hasBooster : eTerrain || hasBooster)) return false;
 	const stats = mon.stats;
 	if (!stats) {
 		// Fall back to a species-base-stat lookup; the Dex import is

--- a/sim/tools/strategic-ai/mechanics/SwitchEvaluator.ts
+++ b/sim/tools/strategic-ai/mechanics/SwitchEvaluator.ts
@@ -129,7 +129,89 @@ export function evaluateMatchup(
 		score -= foeBoosts * 4;
 	}
 
+	// Entry-synergy bonuses: things that happen the moment `mon`
+	// switches in, which the rest of the matchup math doesn't capture
+	// because it works from the *current* tracker state.
+	score += entrySynergyBonus(mon, foe, tracker);
+
 	return { score, weDealFraction, foeDealFraction, speedDelta, hazardFraction };
+}
+
+/**
+ * Score the "switching this mon in right now" effects that aren't
+ * already captured by the static matchup numbers:
+ *
+ * - **Terrain seeds** (Grassy/Electric/Misty/Psychic Seed) trigger on
+ *   entry under the matching terrain and grant a +1 stat boost. Worth
+ *   ~+10 since the boost lingers for the whole stay-in window.
+ * - **Intimidate** drops the foe's Attack on entry. Heavily valuable
+ *   against physical attackers, neutral otherwise.
+ * - **Weather setters** (Drought/Drizzle/Sand Stream/Snow Warning)
+ *   on switch-in: bonus when the weather they set differs from the
+ *   currently-active one and would benefit us (e.g. a Chlorophyll
+ *   teammate would love a sunlight setter). We approximate this as
+ *   "any new weather you bring in is mildly positive".
+ *
+ * @param mon The candidate switch-in.
+ * @param foe The foe currently on the field.
+ * @param tracker Battle state tracker.
+ * @returns A synergy bonus in roughly the [-2, +14] range.
+ */
+function entrySynergyBonus(
+	mon: TrackedPokemon,
+	foe: TrackedPokemon,
+	tracker: BattleStateTracker
+): number {
+	let bonus = 0;
+	const item = toID(mon.item);
+	const ability = toID(mon.ability);
+	const terrain = tracker.field.terrain;
+
+	// Terrain-seed entry boost. The seed is consumed on entry and grants
+	// +1 Def (Grassy/Electric) or +1 SpDef (Misty/Psychic) for the stay.
+	if (
+		(item === "grassyseed" && terrain === "grassyterrain") ||
+		(item === "electricseed" && terrain === "electricterrain") ||
+		(item === "mistyseed" && terrain === "mistyterrain") ||
+		(item === "psychicseed" && terrain === "psychicterrain")
+	) {
+		bonus += 10;
+	}
+
+	// Intimidate: foe loses one stage of Attack on our entry. Scales
+	// with how much the foe was going to lean on Attack.
+	if (ability === "intimidate") {
+		const foeAtk = foe.stats?.atk ?? 0;
+		const foeSpa = foe.stats?.spa ?? 0;
+		// Reduce by ~25% damage on physical hits → ~+6 matchup units;
+		// scale by how physical the foe looks. Pure special attackers
+		// get the floor (the lost Atk is wasted).
+		const physicalLean = foeAtk > foeSpa ? 1 : foeAtk >= foeSpa * 0.85 ? 0.5 : 0.15;
+		// Unaware on the foe ignores our Intimidate drop's offensive
+		// impact, though the stage is still applied; treat that as
+		// neutral.
+		if (toID(foe.ability) === "unaware") bonus += 0;
+		else bonus += 7 * physicalLean;
+	}
+
+	// Weather setters on entry: a switch-in that brings a *new* weather
+	// is usually a positive — either it benefits us directly or it
+	// disrupts the foe's weather-dependent strategy. Capped to +4 so
+	// it doesn't dominate the matchup math.
+	const weatherFromAbility: Record<string, string> = {
+		drought: "sunnyday",
+		drizzle: "raindance",
+		sandstream: "sandstorm",
+		snowwarning: "snowscape",
+		orichalcumpulse: "sunnyday",
+		hadronengine: "electricterrain",
+	};
+	const broughtWeather = weatherFromAbility[ability];
+	if (broughtWeather && broughtWeather !== tracker.field.weather && broughtWeather !== tracker.field.terrain) {
+		bonus += 4;
+	}
+
+	return bonus;
 }
 
 /**
@@ -159,13 +241,31 @@ export function chooseBestSwitch(
 /**
  * Find the best damaging move `attacker` can throw at `defender`.
  *
- * When `useKnownOnly` is true (foe -> us evaluation) we only consider
- * moves the foe has actually revealed; if they haven't revealed any
- * damaging moves yet, we fall back to the best STAB damage assuming
- * a 100 base-power move of each of their STAB types.
+ * We pull every revealed damaging move from the attacker's known set,
+ * AND additionally consider STAB-type proxies derived from the
+ * attacker's species. STAB types are publicly inferable from the
+ * species, so this isn't "cheating": the AI just refuses to pretend
+ * a Garchomp won't have a Ground STAB until it sees Earthquake.
  *
- * For our own evaluation we walk our actual moveset (revealedMoves
- * for our side is seeded by `applyRequest`).
+ * Without this, a foe that has only revealed one of its two STABs
+ * looks artificially safe — so on monotype teams the AI would happily
+ * switch a 4×-weak teammate into an unrevealed coverage hit.
+ *
+ * When `useKnownOnly` is false (our → foe evaluation) we additionally
+ * probe a wider coverage-type shortlist so we estimate our own
+ * unrevealed-but-likely move pool optimistically.
+ *
+ * @param attacker The CalcPokemon snapshot of the attacking side.
+ * @param defender The CalcPokemon snapshot of the defending side.
+ * @param tracker Battle state tracker (provides field / side state).
+ * @param attackerMon TrackedPokemon record for the attacker (move pool).
+ * @param defenderMon TrackedPokemon record for the defender (unused, for symmetry).
+ * @param useKnownOnly True when we're estimating the foe's threat to us:
+ *   skips the wide coverage probe but still includes STAB proxies.
+ * @param attackerSideId Tracker side id of the attacker (for screens/Tailwind).
+ * @param defenderSideId Tracker side id of the defender (for screens/Tailwind).
+ * @returns The highest expected damage roll along with the move id, or `null`
+ *   if no damaging move can be modelled (e.g. an immune defender).
  */
 function bestAttackingDamage(
 	attacker: CalcPokemon,
@@ -177,42 +277,52 @@ function bestAttackingDamage(
 	attackerSideId: SideId,
 	defenderSideId: SideId,
 ): { avgDamage: number, moveId: string } | null {
+	void defenderMon;
 	const moves: Move[] = [];
 	for (const id of attackerMon.revealedMoves) {
 		const m = Dex.moves.get(id);
 		if (m && m.category !== "Status" && m.basePower > 0) moves.push(m);
 	}
-	if (!moves.length) {
-		// Fall back to imagined STAB attacks at BP 100. We synthesise
-		// `Move`-like records via `Dex.getActiveMove` of a placeholder
-		// (Tackle) and override its `type`/`basePower` for the calc.
-		const tackleProto = Dex.moves.get("tackle");
-		for (const t of attackerMon.types) {
+	// Always add STAB proxies for the attacker's effective types — but
+	// only ones the attacker doesn't already cover with a revealed move
+	// of the same type. Species typing is public information, so
+	// assuming the mon has at least *one* damaging STAB option is safe
+	// and prevents the AI from over-trusting an incomplete revealed
+	// list. Skipping types we already see avoids double-counting
+	// (revealed Earthquake + imagined "Proxy Ground" → over-estimate).
+	const revealedTypes = new Set(moves.map(m => m.type));
+	const tackleProto = Dex.moves.get("tackle");
+	const seenProxyTypes = new Set<string>();
+	for (const t of attackerMon.types) {
+		if (seenProxyTypes.has(t) || revealedTypes.has(t)) continue;
+		seenProxyTypes.add(t);
+		// Slightly lower BP for the proxy (80) than a real STAB so the
+		// estimate is "the foe probably has *some* attack of this type"
+		// without claiming it's a guaranteed top-tier hit.
+		moves.push({
+			...tackleProto,
+			id: `proxystab${t.toLowerCase()}` as never,
+			name: `Proxy ${t}`,
+			type: t,
+			category: "Physical",
+			basePower: 80,
+			accuracy: 100,
+		});
+	}
+	if (!useKnownOnly) {
+		// Coverage moves: the most-feared off-type move. We probe a
+		// shortlist of common types; the best one wins.
+		for (const t of COMMON_COVERAGE_TYPES) {
+			if (seenProxyTypes.has(t) || revealedTypes.has(t)) continue;
 			moves.push({
 				...tackleProto,
-				id: `proxy${t.toLowerCase()}` as never,
+				id: `proxycov${t.toLowerCase()}` as never,
 				name: `Proxy ${t}`,
 				type: t,
 				category: "Physical",
-				basePower: 100,
+				basePower: 80,
 				accuracy: 100,
 			});
-		}
-		// Coverage moves: the most-feared off-type move. We probe a
-		// shortlist of common types; the best one wins.
-		if (!useKnownOnly) {
-			for (const t of COMMON_COVERAGE_TYPES) {
-				if (attackerMon.types.includes(t)) continue;
-				moves.push({
-					...tackleProto,
-					id: `proxy${t.toLowerCase()}` as never,
-					name: `Proxy ${t}`,
-					type: t,
-					category: "Physical",
-					basePower: 80,
-					accuracy: 100,
-				});
-			}
 		}
 	}
 	let best: { avgDamage: number, moveId: string } | null = null;

--- a/sim/tools/strategic-ai/state/BattleStateTracker.ts
+++ b/sim/tools/strategic-ai/state/BattleStateTracker.ts
@@ -830,6 +830,20 @@ export class BattleStateTracker {
 	}
 
 	/**
+	 * Groundedness check keyed directly off a {@link TrackedPokemon}
+	 * snapshot (rather than an active slot). Useful for evaluators that
+	 * already hold the mon record and need to know whether terrain
+	 * effects (Electric/Misty Terrain status blocks, terrain BP boosts)
+	 * apply to it.
+	 *
+	 * @param mon The tracked Pokemon to test.
+	 * @returns true if the mon is grounded.
+	 */
+	isPokemonGrounded(mon: TrackedPokemon): boolean {
+		return this.isMonGrounded(mon);
+	}
+
+	/**
 	 * Mon-keyed groundedness check, shared between {@link isGrounded}
 	 * (the active-slot accessor) and {@link hazardDamageFraction} (the
 	 * switch-in projection). Considers Gravity, Iron Ball, Smack Down,

--- a/sim/tools/strategic-ai/state/BattleStateTracker.ts
+++ b/sim/tools/strategic-ai/state/BattleStateTracker.ts
@@ -75,6 +75,14 @@ export interface TrackedPokemon {
 	revealedMoves: Set<string>;
 	/** Last move used (id), if any. */
 	lastMove?: string;
+	/**
+	 * True iff the mon's most recent move attempt did not connect:
+	 * `|miss|`, `|-immune|`, `|-fail|`, or `|cant|` followed by no
+	 * successful `|move|` since. Cleared the next time the mon
+	 * successfully uses a move. Powers Stomping Tantrum's 2× BP and
+	 * any future "failed-move follow-up" heuristics.
+	 */
+	lastMoveFailed: boolean;
 	/** Consecutive-same-move counter. >=2 + holds an item that locks to first move => Choice. */
 	sameMoveStreak: number;
 	/** True if Choice-lock inference has triggered for this mon. */
@@ -216,6 +224,12 @@ export class BattleStateTracker {
 	winner: SideId | null;
 	/** Raw `|win|<name>` payload, when available. */
 	winnerName: string | null;
+	/**
+	 * Most recent attacker — used to attribute miss / immune / fail /
+	 * cant events back to the user whose move just resolved. Cleared
+	 * on turn change.
+	 */
+	private _lastMover: TrackedPokemon | null;
 
 	constructor(options: BattleStateTrackerOptions) {
 		this.mySide = options.mySide;
@@ -238,6 +252,7 @@ export class BattleStateTracker {
 		this.ended = false;
 		this.winner = null;
 		this.winnerName = null;
+		this._lastMover = null;
 	}
 
 	// -------------------------------------------------------------------
@@ -279,6 +294,7 @@ export class BattleStateTracker {
 			types: [],
 			terastallized: false,
 			revealedMoves: new Set(),
+			lastMoveFailed: false,
 			sameMoveStreak: 0,
 			choiceLocked: false,
 			volatiles: new Set(),
@@ -417,6 +433,7 @@ export class BattleStateTracker {
 			case "turn":
 				this.turn = event.turn;
 				this.tickTimedConditions();
+				this._lastMover = null;
 				return;
 			case "gametype":
 				this.gametype = event.gametype;
@@ -448,6 +465,10 @@ export class BattleStateTracker {
 					}
 					mon.lastMove = moveId;
 					mon.revealedMoves.add(moveId);
+					// A new move attempt clears the previous failure flag.
+					// We re-set it later if a `miss` / `immune` / `fail`
+					// follow-up event arrives for this same move.
+					mon.lastMoveFailed = false;
 					// Choice-lock inference: a foe locked into a single move
 					// for two consecutive turns while holding a Choice item
 					// (or one we haven't ruled out) must be Choice-locked.
@@ -455,6 +476,29 @@ export class BattleStateTracker {
 						mon.choiceLocked = true;
 					}
 				}
+				this._lastMover = mon;
+				return;
+			}
+			case "miss": {
+				// `event.source` is the attacker. When it's missing
+				// (older protocol), fall back to the most recent mover.
+				const mon = event.source ?
+					this.resolveByRef(event.source) :
+					this._lastMover;
+				if (mon) mon.lastMoveFailed = true;
+				return;
+			}
+			case "immune": {
+				// `event.pokemon` is the immune *target*; the failing
+				// attacker is the most recent mover.
+				if (this._lastMover) this._lastMover.lastMoveFailed = true;
+				return;
+			}
+			case "fail": {
+				// `event.pokemon` is the failing attacker (or status
+				// target whose move/status fizzled — close enough).
+				const mon = this.resolveByRef(event.pokemon);
+				mon.lastMoveFailed = true;
 				return;
 			}
 			case "switch":
@@ -738,6 +782,7 @@ export class BattleStateTracker {
 				if (event.move) {
 					mon.revealedMoves.add(toID(event.move));
 				}
+				mon.lastMoveFailed = true;
 				return;
 			}
 			default:

--- a/test/sim/tools/strategic-ai/damage-calc.js
+++ b/test/sim/tools/strategic-ai/damage-calc.js
@@ -193,4 +193,110 @@ describe('Strategic-AI DamageCalc', () => {
 		assert(sun.avgDamage > rain.avgDamage,
 			`Sun should boost Fire moves over Rain (sun=${sun.avgDamage}, rain=${rain.avgDamage})`);
 	});
+
+	// Regression: Booster Energy on Paradox mons (Protosynthesis /
+	// Quark Drive) was not boosting the relevant stat in the calc, so
+	// the AI rated Iron Valiant / Roaring Moon / Iron Bundle equally
+	// before and after consuming the item — which led it to switch
+	// them out instead of pressing the boost.
+	describe('Paradox abilities (Protosynthesis / Quark Drive)', () => {
+		it('Protosynthesis under sun raises damage on its highest stat (Roaring Moon)', () => {
+			const sunny = calc({
+				attacker: mkMon('Roaring Moon', { ability: 'protosynthesis' }),
+				defender: mkMon('Skarmory'),
+				move: 'crunch',
+				field: emptyField('sunnyday'),
+			});
+			const noWeather = calc({
+				attacker: mkMon('Roaring Moon', { ability: 'protosynthesis' }),
+				defender: mkMon('Skarmory'),
+				move: 'crunch',
+			});
+			assert(sunny.avgDamage > noWeather.avgDamage * 1.2,
+				`Protosynthesis in sun should boost damage by >20% ` +
+				`(sun=${sunny.avgDamage}, off=${noWeather.avgDamage})`);
+		});
+
+		it('Booster Energy activates Quark Drive without Electric Terrain (Iron Valiant)', () => {
+			// Iron Valiant's base Atk (130) > base SpA (120), so the
+			// boost defaults to Atk. Use a physical move to observe it.
+			const booster = calc({
+				attacker: mkMon('Iron Valiant', {
+					ability: 'quarkdrive', item: 'boosterenergy',
+				}),
+				defender: mkMon('Blissey'),
+				move: 'closecombat',
+			});
+			const plain = calc({
+				attacker: mkMon('Iron Valiant', { ability: 'quarkdrive' }),
+				defender: mkMon('Blissey'),
+				move: 'closecombat',
+			});
+			assert(booster.avgDamage > plain.avgDamage * 1.2,
+				`Booster Energy should activate Quark Drive ` +
+				`(boost=${booster.avgDamage}, off=${plain.avgDamage})`);
+		});
+
+		it('explicit volatile overrides the auto-detected stat', () => {
+			// Force the boost onto Def so a Sp.Atk should NOT see the bump.
+			const forced = calc({
+				attacker: mkMon('Iron Valiant', {
+					ability: 'quarkdrive',
+					item: 'boosterenergy',
+					volatiles: ['quarkdrivedef'],
+				}),
+				defender: mkMon('Blissey'),
+				move: 'moonblast',
+			});
+			const plain = calc({
+				attacker: mkMon('Iron Valiant', { ability: 'quarkdrive' }),
+				defender: mkMon('Blissey'),
+				move: 'moonblast',
+			});
+			// Allow a tiny rounding tolerance; the key check is that
+			// forcing Def doesn't raise SpA damage.
+			assert(Math.abs(forced.avgDamage - plain.avgDamage) < Math.max(2, plain.avgDamage * 0.05),
+				`Defense-typed volatile should NOT lift SpA damage ` +
+				`(forced=${forced.avgDamage}, plain=${plain.avgDamage})`);
+		});
+	});
+
+	// Regression: Solar Power's +50% SpA was missing from the calc, so
+	// in sun the AI under-rated Solar-Power abusers (Charizard-Y,
+	// Heliolisk, etc.) and routinely switched them out.
+	describe('Solar Power', () => {
+		it('+50% SpA in sun for Solar Power user', () => {
+			const sun = calc({
+				attacker: mkMon('Heliolisk', { ability: 'solarpower' }),
+				defender: mkMon('Blissey'),
+				move: 'thunderbolt',
+				field: emptyField('sunnyday'),
+			});
+			const noSun = calc({
+				attacker: mkMon('Heliolisk', { ability: 'solarpower' }),
+				defender: mkMon('Blissey'),
+				move: 'thunderbolt',
+			});
+			assert(sun.avgDamage > noSun.avgDamage * 1.4,
+				`Solar Power in sun should add ~50% to SpA damage ` +
+				`(sun=${sun.avgDamage}, off=${noSun.avgDamage})`);
+		});
+
+		it('does not affect physical moves', () => {
+			const sun = calc({
+				attacker: mkMon('Heliolisk', { ability: 'solarpower' }),
+				defender: mkMon('Blissey'),
+				move: 'quickattack',
+				field: emptyField('sunnyday'),
+			});
+			const noSun = calc({
+				attacker: mkMon('Heliolisk', { ability: 'solarpower' }),
+				defender: mkMon('Blissey'),
+				move: 'quickattack',
+			});
+			assert.equal(sun.avgDamage, noSun.avgDamage,
+				`Solar Power should not change physical move damage ` +
+				`(sun=${sun.avgDamage}, off=${noSun.avgDamage})`);
+		});
+	});
 });

--- a/test/sim/tools/strategic-ai/force-switch.js
+++ b/test/sim/tools/strategic-ai/force-switch.js
@@ -48,6 +48,7 @@ function emptyEngineCtx(tracker) {
 		disabledMovesByMon: new Map(),
 		trappedActiveByMon: new Set(),
 		lastSwitchTurnByMon: new Map(),
+		lastMoveFailedByMon: new Set(),
 		noiseEpsilon: 0,
 		infoForgetting: 0,
 	};

--- a/test/sim/tools/strategic-ai/move-evaluator.js
+++ b/test/sim/tools/strategic-ai/move-evaluator.js
@@ -1,0 +1,231 @@
+'use strict';
+
+/**
+ * Regression coverage for the user-reported AI issues:
+ *
+ * - Destiny Bond was being spammed because it fell into the
+ *   `unknownStatus` fallback (score = 2) which still beat 0-score
+ *   moves like Counter / Mirror Coat.
+ * - Baton Pass was never picked because it also fell into
+ *   `unknownStatus`, so the AI would stack +6 boosts on one mon and
+ *   never pass them.
+ * - Encore had a flat 14 even when the foe just used a damaging move;
+ *   it should be much higher when the foe last used a status / setup
+ *   move (lock them out of attacking).
+ * - Counter / Mirror Coat have `basePower: 0` and a `damageCallback`,
+ *   so the damage path scored them at 0 and they were never picked.
+ *
+ * These tests exercise the corrected `evaluateMove` scoring.
+ */
+
+const assert = require('../../../assert');
+
+const { evaluateMove } =
+	require('../../../../dist/sim/tools/strategic-ai/mechanics/MoveEvaluator');
+const { BattleStateTracker } =
+	require('../../../../dist/sim/tools/strategic-ai/state/BattleStateTracker');
+const { Dex } = require('../../../../dist/sim');
+
+function mkTracked(speciesName, opts = {}) {
+	const species = Dex.species.get(speciesName);
+	if (!species.exists) throw new Error(`Unknown species: ${speciesName}`);
+	return {
+		id: `mon:${species.id}`,
+		name: species.name,
+		species: species.id,
+		level: opts.level ?? 100,
+		condition: '100/100',
+		hpFraction: opts.hpFraction ?? 1,
+		status: opts.status ?? '',
+		boosts: opts.boosts ?? {},
+		types: opts.types ?? [...species.types],
+		teraType: opts.teraType,
+		terastallized: opts.terastallized ?? false,
+		ability: opts.ability ?? '',
+		baseAbility: opts.ability ?? '',
+		item: opts.item ?? '',
+		revealedMoves: new Set(opts.revealedMoves || []),
+		lastMove: opts.lastMove,
+		sameMoveStreak: opts.sameMoveStreak ?? 0,
+		choiceLocked: opts.choiceLocked ?? false,
+		stats: opts.stats,
+		volatiles: new Set(opts.volatiles || []),
+		fainted: !!opts.fainted,
+		active: !!opts.active,
+		position: opts.position ?? -1,
+	};
+}
+
+function freshTracker() {
+	return new BattleStateTracker({ mySide: 'p1' });
+}
+
+function ctxFor(attacker, defender, tracker, overrides = {}) {
+	return {
+		tracker,
+		attacker,
+		defender,
+		mySide: 'p1',
+		foeSide: 'p2',
+		weOutspeed: overrides.weOutspeed ?? true,
+		isDoubles: overrides.isDoubles ?? false,
+		valueOfBestSwitch: overrides.valueOfBestSwitch ?? 0,
+	};
+}
+
+describe('Strategic-AI MoveEvaluator', () => {
+	describe('Destiny Bond', () => {
+		it('is a trash pick at full HP', () => {
+			const tracker = freshTracker();
+			const me = mkTracked('Aegislash', { ability: 'stancechange' });
+			const foe = mkTracked('Garchomp', { revealedMoves: ['earthquake'] });
+			const result = evaluateMove(Dex.moves.get('destinybond'), ctxFor(me, foe, tracker, {
+				weOutspeed: false,
+			}));
+			assert(result.score < 0,
+				`Destiny Bond at full HP should be heavily negative (got ${result.score})`);
+		});
+
+		it('scores high at low HP when the foe is faster', () => {
+			const tracker = freshTracker();
+			const me = mkTracked('Aegislash', { ability: 'stancechange', hpFraction: 0.18 });
+			const foe = mkTracked('Garchomp', { revealedMoves: ['earthquake'] });
+			const result = evaluateMove(Dex.moves.get('destinybond'), ctxFor(me, foe, tracker, {
+				weOutspeed: false,
+			}));
+			assert(result.score > 30,
+				`Destiny Bond at <20% HP vs faster foe should be a top pick (got ${result.score})`);
+		});
+
+		it('is refused when DB is already volatile (cannot be used twice in a row)', () => {
+			const tracker = freshTracker();
+			const me = mkTracked('Aegislash', {
+				ability: 'stancechange', hpFraction: 0.18,
+				volatiles: ['destinybond'],
+			});
+			const foe = mkTracked('Garchomp', { revealedMoves: ['earthquake'] });
+			const result = evaluateMove(Dex.moves.get('destinybond'), ctxFor(me, foe, tracker, {
+				weOutspeed: false,
+			}));
+			assert(result.score < 0,
+				`Destiny Bond with DB volatile up should refuse (got ${result.score})`);
+		});
+	});
+
+	describe('Baton Pass', () => {
+		it('is highly valued when the attacker has positive boosts to pass', () => {
+			const tracker = freshTracker();
+			const me = mkTracked('Espeon', {
+				ability: 'magicbounce',
+				boosts: { spa: 2, spe: 2 },
+			});
+			const foe = mkTracked('Tyranitar', { revealedMoves: ['stoneedge'] });
+			const result = evaluateMove(Dex.moves.get('batonpass'), ctxFor(me, foe, tracker, {
+				valueOfBestSwitch: 10,
+			}));
+			assert(result.score > 30,
+				`Baton Pass with +2 SpA / +2 Spe should be a top pick (got ${result.score})`);
+		});
+
+		it('beats stacking another boost when boosts are already high', () => {
+			const tracker = freshTracker();
+			const me = mkTracked('Espeon', {
+				ability: 'magicbounce',
+				boosts: { spa: 4, spe: 4 },
+			});
+			const foe = mkTracked('Tyranitar', { revealedMoves: ['stoneedge'] });
+			const bp = evaluateMove(Dex.moves.get('batonpass'), ctxFor(me, foe, tracker, {
+				valueOfBestSwitch: 8,
+			}));
+			const nastyPlot = evaluateMove(Dex.moves.get('nastyplot'), ctxFor(me, foe, tracker, {
+				valueOfBestSwitch: 8,
+			}));
+			assert(bp.score > nastyPlot.score,
+				`At +4 SpA, Baton Pass should outscore another Nasty Plot ` +
+				`(BP=${bp.score} NP=${nastyPlot.score})`);
+		});
+
+		it('is unattractive when the attacker has no boosts and no switch target', () => {
+			const tracker = freshTracker();
+			const me = mkTracked('Espeon', { ability: 'magicbounce' });
+			const foe = mkTracked('Tyranitar', { revealedMoves: ['stoneedge'] });
+			const result = evaluateMove(Dex.moves.get('batonpass'), ctxFor(me, foe, tracker, {
+				valueOfBestSwitch: 0,
+			}));
+			assert(result.score < 0,
+				`Boostless Baton Pass with no good target should be negative (got ${result.score})`);
+		});
+	});
+
+	describe('Counter / Mirror Coat', () => {
+		it('Counter scores high when the foe just used a Physical move and we are slower', () => {
+			const tracker = freshTracker();
+			const me = mkTracked('Wobbuffet', { ability: 'shadowtag' });
+			const foe = mkTracked('Garchomp', {
+				revealedMoves: ['earthquake'],
+				lastMove: 'earthquake',
+			});
+			const result = evaluateMove(Dex.moves.get('counter'), ctxFor(me, foe, tracker, {
+				weOutspeed: false,
+			}));
+			assert(result.score > 20,
+				`Counter vs a foe that just used Physical should score >20 (got ${result.score})`);
+		});
+
+		it('Mirror Coat scores high when the foe just used a Special move and we are slower', () => {
+			const tracker = freshTracker();
+			const me = mkTracked('Wobbuffet', { ability: 'shadowtag' });
+			const foe = mkTracked('Heatran', {
+				revealedMoves: ['magmastorm'],
+				lastMove: 'magmastorm',
+			});
+			const result = evaluateMove(Dex.moves.get('mirrorcoat'), ctxFor(me, foe, tracker, {
+				weOutspeed: false,
+			}));
+			assert(result.score > 20,
+				`Mirror Coat vs a foe that just used Special should score >20 (got ${result.score})`);
+		});
+
+		it('Counter outscores Destiny Bond when the foe just used a Physical move', () => {
+			const tracker = freshTracker();
+			const me = mkTracked('Wobbuffet', { ability: 'shadowtag' });
+			const foe = mkTracked('Garchomp', {
+				revealedMoves: ['earthquake'],
+				lastMove: 'earthquake',
+			});
+			const counter = evaluateMove(Dex.moves.get('counter'),
+				ctxFor(me, foe, tracker, { weOutspeed: false }));
+			const db = evaluateMove(Dex.moves.get('destinybond'),
+				ctxFor(me, foe, tracker, { weOutspeed: false }));
+			assert(counter.score > db.score,
+				`Counter should beat Destiny Bond after a Physical hit ` +
+				`(Counter=${counter.score} DB=${db.score})`);
+		});
+	});
+
+	describe('Encore', () => {
+		it('is highly valued when the foe just used a status / setup move', () => {
+			const tracker = freshTracker();
+			const me = mkTracked('Whimsicott', { ability: 'prankster' });
+			const foe = mkTracked('Volcarona', {
+				revealedMoves: ['quiverdance'],
+				lastMove: 'quiverdance',
+			});
+			const result = evaluateMove(Dex.moves.get('encore'), ctxFor(me, foe, tracker));
+			assert(result.score > 20,
+				`Encore vs Quiver Dance user should score >20 (got ${result.score})`);
+		});
+
+		it('is modest when the foe just used a damaging move', () => {
+			const tracker = freshTracker();
+			const me = mkTracked('Whimsicott', { ability: 'prankster' });
+			const foe = mkTracked('Volcarona', {
+				revealedMoves: ['fireblast'],
+				lastMove: 'fireblast',
+			});
+			const result = evaluateMove(Dex.moves.get('encore'), ctxFor(me, foe, tracker));
+			assert(result.score >= 0 && result.score < 20,
+				`Encore vs a pure attacker should be modest (got ${result.score})`);
+		});
+	});
+});

--- a/test/sim/tools/strategic-ai/move-evaluator.js
+++ b/test/sim/tools/strategic-ai/move-evaluator.js
@@ -228,4 +228,85 @@ describe('Strategic-AI MoveEvaluator', () => {
 				`Encore vs a pure attacker should be modest (got ${result.score})`);
 		});
 	});
+
+	// Regression: priority moves only earned a +25 bonus when we were
+	// slower AND would KO. Slow-mon scenarios (Mamoswine / Bisharp at
+	// low HP needing a priority KO) were underrated, and Sucker Punch
+	// was spammed into status/setup mons where it auto-fails.
+	describe('priority move scoring', () => {
+		it('Bullet Punch at low HP into a faster foe scores well above neutral', () => {
+			const tracker = freshTracker();
+			const scizor = mkTracked('Scizor', {
+				ability: 'technician', hpFraction: 0.3,
+				stats: { hp: 343, atk: 394, def: 236, spa: 138, spd: 226, spe: 195 },
+			});
+			const foe = mkTracked('Garchomp', {
+				revealedMoves: ['earthquake'],
+				stats: { hp: 357, atk: 359, def: 246, spa: 222, spd: 237, spe: 333 },
+			});
+			const priority = evaluateMove(Dex.moves.get('bulletpunch'),
+				ctxFor(scizor, foe, tracker, { weOutspeed: false }));
+			const normalAttack = evaluateMove(Dex.moves.get('xscissor'),
+				ctxFor(scizor, foe, tracker, { weOutspeed: false }));
+			// Bullet Punch should be at least competitive with the
+			// stronger X-Scissor because we may not get a second turn.
+			assert(priority.score > normalAttack.score - 5,
+				`Bullet Punch insurance bonus should make it comparable ` +
+				`to X-Scissor when low HP + slower ` +
+				`(BP=${priority.score.toFixed(2)} X=${normalAttack.score.toFixed(2)})`);
+		});
+
+		it('Extreme Speed on a slow attacker rewards the priority KO branch', () => {
+			const tracker = freshTracker();
+			const dragonite = mkTracked('Dragonite', {
+				ability: 'multiscale',
+				stats: { hp: 386, atk: 403, def: 226, spa: 212, spd: 236, spe: 185 },
+			});
+			const weakened = mkTracked('Garchomp', {
+				revealedMoves: ['earthquake'], hpFraction: 0.2,
+				stats: { hp: 357, atk: 359, def: 246, spa: 222, spd: 237, spe: 333 },
+			});
+			const result = evaluateMove(Dex.moves.get('extremespeed'),
+				ctxFor(dragonite, weakened, tracker, { weOutspeed: false }));
+			// At 20% HP a +2 priority Normal-typed STAB attack should
+			// guarantee a KO and earn the stacked-priority bonus.
+			assert(result.score > 35,
+				`Extreme Speed into a sub-20% foe should score >35 ` +
+				`(got ${result.score.toFixed(2)})`);
+		});
+	});
+
+	// Regression: Sucker Punch was being spammed against setup mons
+	// (auto-fails) and was never preferred even when the foe was
+	// choice-locked into a damaging move (guaranteed fire).
+	describe('Sucker Punch', () => {
+		it('hard-negative when the foe just used a status move', () => {
+			const tracker = freshTracker();
+			const bisharp = mkTracked('Bisharp', { ability: 'defiant' });
+			const foe = mkTracked('Volcarona', {
+				revealedMoves: ['quiverdance'],
+				lastMove: 'quiverdance',
+			});
+			const result = evaluateMove(Dex.moves.get('suckerpunch'),
+				ctxFor(bisharp, foe, tracker, { weOutspeed: false }));
+			assert(result.score < 0,
+				`Sucker Punch vs a fresh Quiver Dance user should score ` +
+				`negative — it will auto-fail (got ${result.score})`);
+		});
+
+		it('high score when the foe is choice-locked into a damaging move', () => {
+			const tracker = freshTracker();
+			const bisharp = mkTracked('Bisharp', { ability: 'defiant' });
+			const foe = mkTracked('Heatran', {
+				revealedMoves: ['magmastorm'],
+				lastMove: 'magmastorm',
+				choiceLocked: true,
+			});
+			const result = evaluateMove(Dex.moves.get('suckerpunch'),
+				ctxFor(bisharp, foe, tracker, { weOutspeed: false }));
+			assert(result.score > 25,
+				`Sucker Punch into a Choice-locked attacker should score >25 ` +
+				`(got ${result.score})`);
+		});
+	});
 });

--- a/test/sim/tools/strategic-ai/move-evaluator.js
+++ b/test/sim/tools/strategic-ai/move-evaluator.js
@@ -89,15 +89,27 @@ describe('Strategic-AI MoveEvaluator', () => {
 				`Destiny Bond at full HP should be heavily negative (got ${result.score})`);
 		});
 
-		it('scores high at low HP when the foe is faster', () => {
+		it('scores high at low HP when we move first (so the bond resolves before we faint)', () => {
+			const tracker = freshTracker();
+			const me = mkTracked('Aegislash', { ability: 'stancechange', hpFraction: 0.18 });
+			const foe = mkTracked('Garchomp', { revealedMoves: ['earthquake'] });
+			const result = evaluateMove(Dex.moves.get('destinybond'), ctxFor(me, foe, tracker, {
+				weOutspeed: true,
+			}));
+			assert(result.score > 30,
+				`Destiny Bond at <20% HP when we outspeed should be a top pick (got ${result.score})`);
+		});
+
+		it('is a weak pick at low HP when the foe outspeeds and KOs before the bond is up', () => {
 			const tracker = freshTracker();
 			const me = mkTracked('Aegislash', { ability: 'stancechange', hpFraction: 0.18 });
 			const foe = mkTracked('Garchomp', { revealedMoves: ['earthquake'] });
 			const result = evaluateMove(Dex.moves.get('destinybond'), ctxFor(me, foe, tracker, {
 				weOutspeed: false,
 			}));
-			assert(result.score > 30,
-				`Destiny Bond at <20% HP vs faster foe should be a top pick (got ${result.score})`);
+			assert(result.score < 0,
+				`Destiny Bond into a faster KO should be negative — it whiffs ` +
+				`before resolving (got ${result.score})`);
 		});
 
 		it('is refused when DB is already volatile (cannot be used twice in a row)', () => {
@@ -187,6 +199,21 @@ describe('Strategic-AI MoveEvaluator', () => {
 			}));
 			assert(result.score > 20,
 				`Mirror Coat vs a foe that just used Special should score >20 (got ${result.score})`);
+		});
+
+		it('Counter still scores high when we OUTSPEED (−5 priority always moves last)', () => {
+			const tracker = freshTracker();
+			const me = mkTracked('Wobbuffet', { ability: 'shadowtag' });
+			const foe = mkTracked('Garchomp', {
+				revealedMoves: ['earthquake'],
+				lastMove: 'earthquake',
+			});
+			const result = evaluateMove(Dex.moves.get('counter'), ctxFor(me, foe, tracker, {
+				weOutspeed: true,
+			}));
+			assert(result.score > 20,
+				`Counter should still score high when we outspeed — its −5 ` +
+				`priority makes it resolve after the foe anyway (got ${result.score})`);
 		});
 
 		it('Counter outscores Destiny Bond when the foe just used a Physical move', () => {

--- a/test/sim/tools/strategic-ai/move-evaluator.js
+++ b/test/sim/tools/strategic-ai/move-evaluator.js
@@ -46,6 +46,7 @@ function mkTracked(speciesName, opts = {}) {
 		item: opts.item ?? '',
 		revealedMoves: new Set(opts.revealedMoves || []),
 		lastMove: opts.lastMove,
+		lastMoveFailed: !!opts.lastMoveFailed,
 		sameMoveStreak: opts.sameMoveStreak ?? 0,
 		choiceLocked: opts.choiceLocked ?? false,
 		stats: opts.stats,
@@ -70,6 +71,8 @@ function ctxFor(attacker, defender, tracker, overrides = {}) {
 		weOutspeed: overrides.weOutspeed ?? true,
 		isDoubles: overrides.isDoubles ?? false,
 		valueOfBestSwitch: overrides.valueOfBestSwitch ?? 0,
+		attackerLastMoveFailed:
+			overrides.attackerLastMoveFailed ?? !!attacker.lastMoveFailed,
 	};
 }
 
@@ -306,6 +309,417 @@ describe('Strategic-AI MoveEvaluator', () => {
 				ctxFor(bisharp, foe, tracker, { weOutspeed: false }));
 			assert(result.score > 25,
 				`Sucker Punch into a Choice-locked attacker should score >25 ` +
+				`(got ${result.score})`);
+		});
+	});
+
+	// Regression: Sash / Sturdy mons at full HP were swapping out or
+	// trading hits instead of investing in setup moves — the "free
+	// turn" the Sash buys was wasted.
+	describe('setup-window bonus (guaranteed survival)', () => {
+		it('Swords Dance scores higher on a Focus Sash holder at full HP', () => {
+			const tracker = freshTracker();
+			const sash = mkTracked('Garchomp', {
+				ability: 'roughskin', item: 'focussash',
+			});
+			const plain = mkTracked('Garchomp', { ability: 'roughskin' });
+			const foe = mkTracked('Skarmory', { revealedMoves: ['bravebird'] });
+			const sashSD = evaluateMove(Dex.moves.get('swordsdance'),
+				ctxFor(sash, foe, tracker, { weOutspeed: false }));
+			const plainSD = evaluateMove(Dex.moves.get('swordsdance'),
+				ctxFor(plain, foe, tracker, { weOutspeed: false }));
+			assert(sashSD.score > plainSD.score + 10,
+				`Sash holder should value Swords Dance much higher ` +
+				`(sash=${sashSD.score} plain=${plainSD.score})`);
+		});
+
+		it('Sturdy + full HP also lifts setup-move scores', () => {
+			const tracker = freshTracker();
+			const sturdy = mkTracked('Carracosta', { ability: 'sturdy' });
+			const plain = mkTracked('Carracosta', { ability: 'solidrock' });
+			const foe = mkTracked('Garchomp', {
+				revealedMoves: ['earthquake'],
+				lastMove: 'earthquake',
+			});
+			const sturdyShell = evaluateMove(Dex.moves.get('shellsmash'),
+				ctxFor(sturdy, foe, tracker, { weOutspeed: false }));
+			const plainShell = evaluateMove(Dex.moves.get('shellsmash'),
+				ctxFor(plain, foe, tracker, { weOutspeed: false }));
+			assert(sturdyShell.score > plainShell.score + 10,
+				`Sturdy user should value Shell Smash higher than a ` +
+				`non-Sturdy peer (sturdy=${sturdyShell.score} ` +
+				`plain=${plainShell.score})`);
+		});
+
+		it('low-HP Sash holder does NOT get the bonus (Sash already broken)', () => {
+			const tracker = freshTracker();
+			const me = mkTracked('Garchomp', {
+				ability: 'roughskin', item: 'focussash', hpFraction: 0.4,
+			});
+			const foe = mkTracked('Skarmory', { revealedMoves: ['bravebird'] });
+			const result = evaluateMove(Dex.moves.get('swordsdance'),
+				ctxFor(me, foe, tracker, { weOutspeed: false }));
+			// Without the bonus, +1 Atk from 0 base should score around
+			// 1 * 9 * 1 = 9 — definitely not in the >20 setup-window
+			// region.
+			assert(result.score < 20,
+				`Sash at 40% HP should not earn the setup-window bonus ` +
+				`(got ${result.score})`);
+		});
+	});
+
+	// Regression: hazard moves had a flat per-foe value, so Sticky
+	// Web (the most impactful hazard) and Stealth Rock scored the
+	// same — the AI would set Spikes first because they appeared
+	// earlier in the move list / picked at random.
+	describe('hazard prioritization', () => {
+		// Populate the tracker with five fake foes so the per-foe
+		// hazard value isn't suppressed by the "remainingFoes <= 1"
+		// guard in `hazardSetValue`.
+		function seedFoeTeam(tracker) {
+			for (let i = 0; i < 5; i++) {
+				const mon = mkTracked('Tauros', {
+					name: `Mon${i}`, fainted: false, active: i === 0,
+				});
+				mon.id = `p2:Mon${i}`;
+				tracker.pokemon.set(mon.id, mon);
+			}
+		}
+
+		it('Sticky Web outscores Stealth Rock when both are available', () => {
+			const tracker = freshTracker();
+			seedFoeTeam(tracker);
+			const me = mkTracked('Smeargle', { ability: 'owntempo' });
+			const foe = mkTracked('Tauros', { revealedMoves: ['bodyslam'] });
+			const web = evaluateMove(Dex.moves.get('stickyweb'),
+				ctxFor(me, foe, tracker));
+			const sr = evaluateMove(Dex.moves.get('stealthrock'),
+				ctxFor(me, foe, tracker));
+			const spikes = evaluateMove(Dex.moves.get('spikes'),
+				ctxFor(me, foe, tracker));
+			assert(web.score > sr.score,
+				`Sticky Web should outscore Stealth Rock ` +
+				`(web=${web.score} sr=${sr.score})`);
+			assert(sr.score > spikes.score,
+				`Stealth Rock should outscore Spikes ` +
+				`(sr=${sr.score} spikes=${spikes.score})`);
+		});
+
+		it('Sturdy at full HP boosts a hazard set', () => {
+			const trackerSturdy = freshTracker();
+			const trackerPlain = freshTracker();
+			seedFoeTeam(trackerSturdy);
+			seedFoeTeam(trackerPlain);
+			const sturdy = mkTracked('Forretress', { ability: 'sturdy' });
+			const plain = mkTracked('Forretress', { ability: 'overcoat' });
+			const foe = mkTracked('Tauros', { revealedMoves: ['bodyslam'] });
+			const sturdyRocks = evaluateMove(Dex.moves.get('stealthrock'),
+				ctxFor(sturdy, foe, trackerSturdy));
+			const plainRocks = evaluateMove(Dex.moves.get('stealthrock'),
+				ctxFor(plain, foe, trackerPlain));
+			assert(sturdyRocks.score > plainRocks.score + 5,
+				`Sturdy user should value SR higher than a non-Sturdy ` +
+				`peer (sturdy=${sturdyRocks.score} plain=${plainRocks.score})`);
+		});
+	});
+
+	// Regression: Yawn was bucketed under `unknownStatus` (+2), so
+	// stall users (Slowking, Politoed) ignored it in favour of
+	// damaging moves that did nothing strategically.
+	describe('Yawn / status-induce stall combos', () => {
+		it('Yawn scores well above the unknown-status fallback', () => {
+			const tracker = freshTracker();
+			const slowking = mkTracked('Slowking', { ability: 'regenerator' });
+			const foe = mkTracked('Garchomp', { revealedMoves: ['earthquake'] });
+			const result = evaluateMove(Dex.moves.get('yawn'),
+				ctxFor(slowking, foe, tracker));
+			assert(result.score >= 15,
+				`Yawn should score >= 15 against an unstatused foe ` +
+				`(got ${result.score})`);
+		});
+
+		it('Yawn is rejected on Misty Terrain (sleep is blocked)', () => {
+			const tracker = freshTracker();
+			tracker.field.terrain = 'mistyterrain';
+			const slowking = mkTracked('Slowking', { ability: 'regenerator' });
+			const foe = mkTracked('Garchomp', { revealedMoves: ['earthquake'] });
+			const result = evaluateMove(Dex.moves.get('yawn'),
+				ctxFor(slowking, foe, tracker));
+			assert(result.score < 0,
+				`Yawn should be rejected under Misty Terrain ` +
+				`(got ${result.score})`);
+		});
+
+		it('Toxic gets a small bonus when we have Protect + Recovery revealed', () => {
+			const tracker = freshTracker();
+			const stall = mkTracked('Toxapex', {
+				ability: 'regenerator',
+				revealedMoves: ['protect', 'recover'],
+			});
+			const stallNoCombo = mkTracked('Toxapex', {
+				ability: 'regenerator',
+				revealedMoves: [],
+			});
+			const foe = mkTracked('Garchomp', { revealedMoves: ['earthquake'] });
+			const combo = evaluateMove(Dex.moves.get('toxic'),
+				ctxFor(stall, foe, tracker));
+			const plain = evaluateMove(Dex.moves.get('toxic'),
+				ctxFor(stallNoCombo, foe, tracker));
+			assert(combo.score > plain.score,
+				`Toxic with Protect + Recover should score higher than ` +
+				`without (combo=${combo.score} plain=${plain.score})`);
+		});
+	});
+
+	// Regression: Weakness Policy holders set up via Sword Dance /
+	// Calm Mind even when slower than the foe — the resulting +2/+2/0
+	// sweeper still got picked off the next turn because Speed never
+	// climbed. WP setups should prefer Dragon Dance / Shift Gear /
+	// Quiver Dance when Speed isn't already won.
+	describe('Weakness Policy setup-window speed prioritization', () => {
+		// A WP holder with foe-revealed SE move triggers `inSetupWindow`.
+		function makeWpVsSE(item = 'weaknesspolicy', spe = false) {
+			const tracker = freshTracker();
+			const me = mkTracked('Garchomp', {
+				ability: 'roughskin', item,
+				stats: { hp: 357, atk: 359, def: 246, spa: 222, spd: 237, spe: 333 },
+			});
+			const foe = mkTracked('Weavile', {
+				revealedMoves: ['iceshard', 'icicleCrash'],
+			});
+			return { tracker, me, foe, weOutspeed: spe };
+		}
+
+		it('Dragon Dance outscores Swords Dance on a WP holder vs SE foe when slower', () => {
+			const { tracker, me, foe } = makeWpVsSE('weaknesspolicy', false);
+			const dd = evaluateMove(Dex.moves.get('dragondance'),
+				ctxFor(me, foe, tracker, { weOutspeed: false }));
+			const sd = evaluateMove(Dex.moves.get('swordsdance'),
+				ctxFor(me, foe, tracker, { weOutspeed: false }));
+			assert(dd.score > sd.score + 5,
+				`Slower WP holder vs SE-foe should prefer Dragon Dance ` +
+				`over Swords Dance (DD=${dd.score} SD=${sd.score})`);
+		});
+
+		it('Dragon Dance does NOT get the extra Spe bonus when we already outspeed', () => {
+			const { tracker, me, foe } = makeWpVsSE('weaknesspolicy', true);
+			const dd = evaluateMove(Dex.moves.get('dragondance'),
+				ctxFor(me, foe, tracker, { weOutspeed: true }));
+			const sd = evaluateMove(Dex.moves.get('swordsdance'),
+				ctxFor(me, foe, tracker, { weOutspeed: true }));
+			// Already outspeeding → no extra reward for Spe specifically.
+			// SD's pure +2 Atk should beat DD's +1/+1 in that world.
+			assert(dd.score < sd.score + 8,
+				`When we already outspeed, the speed bonus shouldn't ` +
+				`unconditionally push DD above SD (DD=${dd.score} SD=${sd.score})`);
+		});
+
+		it('non-WP holder does NOT get the setup-window WP bonus', () => {
+			const tracker = freshTracker();
+			const me = mkTracked('Garchomp', {
+				ability: 'roughskin', item: 'leftovers',
+				stats: { hp: 357, atk: 359, def: 246, spa: 222, spd: 237, spe: 333 },
+			});
+			const foe = mkTracked('Weavile', {
+				revealedMoves: ['iceshard'],
+			});
+			const dd = evaluateMove(Dex.moves.get('dragondance'),
+				ctxFor(me, foe, tracker, { weOutspeed: false }));
+			// Score should be in the normal range (no setup-window
+			// boost). +1/+1 from 0 stages ≈ 9 + 12 = 21 raw — without
+			// the +18 setup bonus.
+			assert(dd.score < 30,
+				`Non-WP holder should not earn the WP setup bonus ` +
+				`(got ${dd.score})`);
+		});
+	});
+
+	// Regression: hazard moves on a low-HP setter scored -8 (because
+	// `attacker.hpFraction < 0.25`), so a Sturdy/Sash mon already
+	// down to 10% would refuse to leave hazards as a parting gift.
+	// Suicide hazards are now valued positively.
+	describe('hazard suicide-set bonus', () => {
+		function seedFoeTeam(tracker) {
+			for (let i = 0; i < 5; i++) {
+				const mon = mkTracked('Tauros', {
+					name: `Mon${i}`, fainted: false, active: i === 0,
+				});
+				mon.id = `p2:Mon${i}`;
+				tracker.pokemon.set(mon.id, mon);
+			}
+		}
+
+		it('Stealth Rock at 12% HP still scores positively', () => {
+			const tracker = freshTracker();
+			seedFoeTeam(tracker);
+			const dying = mkTracked('Forretress', {
+				ability: 'sturdy', hpFraction: 0.12,
+			});
+			const foe = mkTracked('Tauros', { revealedMoves: ['bodyslam'] });
+			const sr = evaluateMove(Dex.moves.get('stealthrock'),
+				ctxFor(dying, foe, tracker, { weOutspeed: false }));
+			assert(sr.score > 10,
+				`Stealth Rock from a 12% HP mon should still earn ` +
+				`a healthy positive score (got ${sr.score})`);
+		});
+	});
+
+	// Regression: conditional-power moves were left at their bare
+	// base-power in the calc, so Bolt Beak / Hex / Payback never
+	// reflected their actual value when their condition was met.
+	describe('conditional base-power moves', () => {
+		it('Hex doubles damage on a statused foe', () => {
+			const tracker = freshTracker();
+			const gengar = mkTracked('Gengar', { ability: 'cursedbody' });
+			// Use a Ghost-vulnerable foe — Hex can't hit Normal types
+			// at all (Ghost vs Normal = immune).
+			const healthy = mkTracked('Latias', {});
+			const statused = mkTracked('Latias', { status: 'tox' });
+			const noStatus = evaluateMove(Dex.moves.get('hex'),
+				ctxFor(gengar, healthy, tracker));
+			const withStatus = evaluateMove(Dex.moves.get('hex'),
+				ctxFor(gengar, statused, tracker));
+			assert(withStatus.score > noStatus.score * 1.5,
+				`Hex should be much higher on a Toxic-poisoned foe ` +
+				`(no=${noStatus.score} status=${withStatus.score})`);
+		});
+
+		it('Bolt Beak doubles power when we move first', () => {
+			const tracker = freshTracker();
+			const dracozolt = mkTracked('Dracovish', {
+				ability: 'strongjaw',
+				types: ['Water', 'Dragon'],
+				stats: { hp: 343, atk: 358, def: 246, spa: 138, spd: 236, spe: 270 },
+			});
+			const foe = mkTracked('Blissey', {});
+			const first = evaluateMove(Dex.moves.get('fishiousrend'),
+				ctxFor(dracozolt, foe, tracker, { weOutspeed: true }));
+			const second = evaluateMove(Dex.moves.get('fishiousrend'),
+				ctxFor(dracozolt, foe, tracker, { weOutspeed: false }));
+			assert(first.score > second.score * 1.4,
+				`Fishious Rend should be sharply higher when moving ` +
+				`first (first=${first.score} second=${second.score})`);
+		});
+
+		it('Payback gets a big bump when we are slower', () => {
+			const tracker = freshTracker();
+			const me = mkTracked('Snorlax', {
+				ability: 'thickfat',
+				stats: { hp: 521, atk: 350, def: 230, spa: 176, spd: 230, spe: 130 },
+			});
+			const foe = mkTracked('Tapu Lele', {});
+			const slower = evaluateMove(Dex.moves.get('payback'),
+				ctxFor(me, foe, tracker, { weOutspeed: false }));
+			const faster = evaluateMove(Dex.moves.get('payback'),
+				ctxFor(me, foe, tracker, { weOutspeed: true }));
+			assert(slower.score > faster.score * 1.4,
+				`Payback should be much higher when moving second ` +
+				`(slow=${slower.score} fast=${faster.score})`);
+		});
+
+		it('Stomping Tantrum doubles after our previous move failed', () => {
+			const tracker = freshTracker();
+			const me = mkTracked('Excadrill', {
+				ability: 'sandrush',
+				stats: { hp: 322, atk: 369, def: 196, spa: 122, spd: 196, spe: 302 },
+			});
+			const foe = mkTracked('Gengar', { types: ['Ghost', 'Poison'] });
+			const afterFail = evaluateMove(Dex.moves.get('stompingtantrum'),
+				ctxFor(me, foe, tracker, { attackerLastMoveFailed: true }));
+			const clean = evaluateMove(Dex.moves.get('stompingtantrum'),
+				ctxFor(me, foe, tracker, { attackerLastMoveFailed: false }));
+			assert(afterFail.score > clean.score * 1.4,
+				`Stomping Tantrum should be much higher after a failed ` +
+				`move (failed=${afterFail.score} clean=${clean.score})`);
+		});
+	});
+
+	// Regression: always-crit moves (Wicked Blow, Surging Strikes,
+	// Flower Trick, Storm Throw, Frost Breath, Zippy Zap) were
+	// scored at non-crit damage, so a Wicked Blow vs a +6 Iron Defense
+	// Cosmoem was treated as a chip noise move.
+	describe('always-crit moves', () => {
+		it('Wicked Blow ignores defender Def boosts', () => {
+			const tracker = freshTracker();
+			const urshifu = mkTracked('Urshifu', {
+				ability: 'unseenfist',
+				types: ['Fighting', 'Dark'],
+				stats: { hp: 351, atk: 410, def: 245, spa: 154, spd: 222, spe: 261 },
+			});
+			const buffyFoe = mkTracked('Avalugg', {
+				boosts: { def: 6 },
+				stats: { hp: 477, atk: 296, def: 386, spa: 99, spd: 154, spe: 86 },
+			});
+			const plainFoe = mkTracked('Avalugg', {
+				stats: { hp: 477, atk: 296, def: 386, spa: 99, spd: 154, spe: 86 },
+			});
+			const vsBoosted = evaluateMove(Dex.moves.get('wickedblow'),
+				ctxFor(urshifu, buffyFoe, tracker));
+			const vsPlain = evaluateMove(Dex.moves.get('wickedblow'),
+				ctxFor(urshifu, plainFoe, tracker));
+			// With crit ignoring +6 Def, the damage delta vs the
+			// boosted target should be tiny (within 10% of the plain
+			// target). Without the crit fix it would be a fraction.
+			assert(vsBoosted.score > vsPlain.score * 0.7,
+				`Wicked Blow vs +6 Def should not collapse — crit ` +
+				`ignores stages (boosted=${vsBoosted.score} ` +
+				`plain=${vsPlain.score})`);
+		});
+
+		it('Wicked Blow scores higher than a non-crit equivalent BP move', () => {
+			const tracker = freshTracker();
+			const urshifu = mkTracked('Urshifu', {
+				ability: 'unseenfist',
+				types: ['Fighting', 'Dark'],
+				stats: { hp: 351, atk: 410, def: 245, spa: 154, spd: 222, spe: 261 },
+			});
+			const foe = mkTracked('Avalugg', {
+				boosts: { def: 6 },
+				stats: { hp: 477, atk: 296, def: 386, spa: 99, spd: 154, spe: 86 },
+			});
+			const wicked = evaluateMove(Dex.moves.get('wickedblow'),
+				ctxFor(urshifu, foe, tracker));
+			// Use Sucker Punch as a same-BP physical Dark comparator.
+			// (Both 75 BP, both Dark, both Physical; only crit differs.)
+			const sucker = evaluateMove(Dex.moves.get('suckerpunch'),
+				ctxFor(urshifu, foe, tracker, { weOutspeed: true }));
+			assert(wicked.score > sucker.score,
+				`Wicked Blow (always-crit) should outscore a same-BP ` +
+				`Dark move vs +6 Def (wicked=${wicked.score} ` +
+				`sucker=${sucker.score})`);
+		});
+	});
+
+	// Regression: Endure was scored via the `unknownStatus` fallback
+	// and so showed up at +2 — the AI burned turns on it without a
+	// pinch berry to capitalise.
+	describe('Endure', () => {
+		it('high score when paired with a pinch-activation Salac Berry at sub-60% HP', () => {
+			const tracker = freshTracker();
+			const me = mkTracked('Sceptile', {
+				ability: 'overgrow', item: 'salacberry', hpFraction: 0.45,
+			});
+			const foe = mkTracked('Garchomp', {
+				revealedMoves: ['earthquake'],
+				lastMove: 'earthquake',
+			});
+			const result = evaluateMove(Dex.moves.get('endure'),
+				ctxFor(me, foe, tracker, { weOutspeed: false }));
+			assert(result.score > 15,
+				`Endure + Salac Berry pinch combo should score >15 ` +
+				`(got ${result.score})`);
+		});
+
+		it('refused when we already hold a fresh Focus Sash at full HP', () => {
+			const tracker = freshTracker();
+			const me = mkTracked('Sceptile', {
+				ability: 'overgrow', item: 'focussash',
+			});
+			const foe = mkTracked('Garchomp', { revealedMoves: ['earthquake'] });
+			const result = evaluateMove(Dex.moves.get('endure'),
+				ctxFor(me, foe, tracker, { weOutspeed: false }));
+			assert(result.score < 0,
+				`Endure is redundant with a fresh Focus Sash ` +
 				`(got ${result.score})`);
 		});
 	});

--- a/test/sim/tools/strategic-ai/switch-evaluator.js
+++ b/test/sim/tools/strategic-ai/switch-evaluator.js
@@ -280,4 +280,105 @@ describe('Strategic-AI SwitchEvaluator', () => {
 				`plain=${plain.score.toFixed(2)})`);
 		});
 	});
+
+	// Regression: the AI happily switched in mons that would get
+	// OHKO'd on entry (4× weak teammate "just to activate Booster
+	// Energy" / sacrifice into a setup-mon to swap back). The fix
+	// stacks an explicit penalty when the foe's best move would KO
+	// the candidate.
+	describe('survivability gate', () => {
+		it('refuses to pick a 4× weak switch-in over a neutral one', () => {
+			const tracker = freshTracker();
+			// Salamence reveals only Earthquake; both candidates take
+			// neutral damage from EQ, but Mega Beedrill / Magnezone
+			// are 4× weak to either Ice Beam (special) or Earthquake.
+			const garchomp = mkTracked('Garchomp', {
+				ability: 'sandveil',
+				revealedMoves: ['earthquake', 'icebeam'],
+			});
+			// Magnezone (Electric/Steel) is 4× weak to Earthquake.
+			const magnezone = mkTracked('Magnezone', {
+				ability: 'magnetpull',
+				revealedMoves: ['flashcannon'],
+			});
+			// Skarmory (Steel/Flying) is immune to Earthquake.
+			const skarmory = mkTracked('Skarmory', {
+				ability: 'sturdy',
+				revealedMoves: ['bravebird'],
+			});
+			const picked = chooseBestSwitch([magnezone, skarmory], garchomp, tracker);
+			assert(picked, 'should return a chosen mon');
+			assert.equal(picked.mon.species, 'skarmory',
+				`should NOT pick the 4× Ground-weak Magnezone over ` +
+				`an EQ-immune Skarmory (picked ${picked.mon.species})`);
+		});
+
+		it('explicit survivability penalty drops the score when foe OHKOs', () => {
+			const tracker = freshTracker();
+			const ttar = mkTracked('Tyranitar', {
+				ability: 'sandstream',
+				revealedMoves: ['stoneedge', 'crunch'],
+			});
+			// Charizard takes ~62.5% from Stealth Rock alone (4× Rock
+			// weakness), then ~150% from Stone Edge — guaranteed OHKO.
+			const charizard = mkTracked('Charizard', {
+				ability: 'blaze',
+				revealedMoves: ['flamethrower'],
+			});
+			tracker.sides.p1.stealthRock = true;
+			const ms = evaluateMatchup(charizard, ttar, tracker);
+			assert(ms.score < -20,
+				`Charizard into TTar+SR should be deeply negative ` +
+				`(got ${ms.score.toFixed(2)})`);
+		});
+	});
+
+	// Regression: monotype team Pokemon with weather-speed abilities
+	// (Chlorophyll under sun, Swift Swim under rain, etc.) didn't
+	// receive an entry bonus, so the AI under-valued them as switch-ins
+	// even when the weather was already up.
+	describe('weather-speed synergy', () => {
+		it('Chlorophyll switch-in is preferred under sun when it outruns the foe', () => {
+			const trackerSun = freshTracker();
+			trackerSun.field.weather = 'sunnyday';
+			const trackerNoSun = freshTracker();
+			// Foe is faster than Venusaur normally (base 80 vs 80 → tie,
+			// but Garchomp has 102 base Speed → outspeeds without sun;
+			// with sun, Venusaur effectively 160 Speed → outspeeds).
+			const garchomp = mkTracked('Garchomp', {
+				revealedMoves: ['earthquake'],
+				stats: { hp: 357, atk: 359, def: 246, spa: 222, spd: 237, spe: 333 },
+			});
+			const venusaur = mkTracked('Venusaur', {
+				ability: 'chlorophyll',
+				revealedMoves: ['gigadrain'],
+				stats: { hp: 364, atk: 226, def: 226, spa: 318, spd: 318, spe: 240 },
+			});
+			const sunny = evaluateMatchup(venusaur, garchomp, trackerSun);
+			const noSun = evaluateMatchup(venusaur, garchomp, trackerNoSun);
+			assert(sunny.score > noSun.score + 5,
+				`Chlorophyll should boost matchup score under sun ` +
+				`(sun=${sunny.score.toFixed(2)} no-sun=${noSun.score.toFixed(2)})`);
+		});
+
+		it('Booster Energy holder gets an entry bonus when field will not auto-activate', () => {
+			const trackerNeutral = freshTracker();
+			const trackerTerrain = freshTracker();
+			trackerTerrain.field.terrain = 'electricterrain';
+			const foe = mkTracked('Garchomp', { revealedMoves: ['earthquake'] });
+			// Iron Valiant w/ Quark Drive + Booster Energy. On Electric
+			// Terrain it'll boost naturally; off-field, Booster Energy
+			// triggers — the entry bonus should reflect "Booster fires
+			// only when field won't already cover us".
+			const valiantBoosted = mkTracked('Iron Valiant', {
+				ability: 'quarkdrive', item: 'boosterenergy',
+				revealedMoves: ['moonblast'],
+			});
+			const neutral = evaluateMatchup(valiantBoosted, foe, trackerNeutral);
+			const onTerrain = evaluateMatchup(valiantBoosted, foe, trackerTerrain);
+			assert(neutral.score > onTerrain.score,
+				`Booster Energy entry bonus should be greater off-field ` +
+				`(neutral=${neutral.score.toFixed(2)} terrain=${onTerrain.score.toFixed(2)})`);
+		});
+	});
 });

--- a/test/sim/tools/strategic-ai/switch-evaluator.js
+++ b/test/sim/tools/strategic-ai/switch-evaluator.js
@@ -34,6 +34,7 @@ function mkTracked(speciesName, opts = {}) {
 		item: opts.item ?? '',
 		revealedMoves: new Set(opts.revealedMoves || []),
 		lastMove: opts.lastMove,
+		lastMoveFailed: !!opts.lastMoveFailed,
 		sameMoveStreak: opts.sameMoveStreak ?? 0,
 		choiceLocked: opts.choiceLocked ?? false,
 		stats: opts.stats,
@@ -379,6 +380,190 @@ describe('Strategic-AI SwitchEvaluator', () => {
 			assert(neutral.score > onTerrain.score,
 				`Booster Energy entry bonus should be greater off-field ` +
 				`(neutral=${neutral.score.toFixed(2)} terrain=${onTerrain.score.toFixed(2)})`);
+		});
+	});
+
+	// Regression: stall Pokemon with absorption / punish abilities
+	// (Flash Fire, Storm Drain, Water Absorb, etc.) didn't earn an
+	// extra switch-in bonus when the foe had revealed a matching move
+	// — even though the matchup is essentially "free turn + heal/boost".
+	describe('absorb/punish ability switch-in synergy', () => {
+		it('Flash Fire user is preferred over a neutral Fire-resist when foe revealed a Fire move', () => {
+			const tracker = freshTracker();
+			const heatran = mkTracked('Heatran', {
+				ability: 'flashfire',
+				revealedMoves: ['lavaplume'],
+			});
+			const garchomp = mkTracked('Garchomp', {
+				revealedMoves: ['earthquake'],
+				stats: { hp: 357, atk: 359, def: 246, spa: 222, spd: 237, spe: 333 },
+			});
+			// Charizard is a foe that has revealed Flamethrower.
+			const charizard = mkTracked('Charizard', {
+				revealedMoves: ['flamethrower'],
+				lastMove: 'flamethrower',
+				stats: { hp: 297, atk: 226, def: 226, spa: 348, spd: 248, spe: 328 },
+			});
+			const picked = chooseBestSwitch([garchomp, heatran], charizard, tracker);
+			assert(picked, 'should return a chosen mon');
+			assert.equal(picked.mon.species, 'heatran',
+				`should pick Flash Fire Heatran over Garchomp into a ` +
+				`revealed-Flamethrower foe (picked ${picked.mon.species})`);
+		});
+
+		it('Water Absorb user beats a generic Water-resist when foe revealed Surf', () => {
+			const tracker = freshTracker();
+			const vaporeon = mkTracked('Vaporeon', {
+				ability: 'waterabsorb',
+				revealedMoves: ['scald'],
+			});
+			const ferrothorn = mkTracked('Ferrothorn', {
+				ability: 'ironbarbs',
+				revealedMoves: ['powerwhip'],
+			});
+			const milotic = mkTracked('Milotic', {
+				revealedMoves: ['surf'],
+				lastMove: 'surf',
+			});
+			const picked = chooseBestSwitch([ferrothorn, vaporeon], milotic, tracker);
+			assert(picked, 'should return a chosen mon');
+			assert.equal(picked.mon.species, 'vaporeon',
+				`should pick Water Absorb Vaporeon over Grass-resist Ferrothorn ` +
+				`(picked ${picked.mon.species})`);
+		});
+
+		it('Levitate user gets the absorb bonus into a foe with a Ground move revealed', () => {
+			const tracker = freshTracker();
+			// Two equally-OK Ground-resisters; Bronzong has Levitate.
+			const bronzong = mkTracked('Bronzong', {
+				ability: 'levitate',
+				revealedMoves: ['psychic'],
+			});
+			const skarmory = mkTracked('Skarmory', {
+				ability: 'sturdy',
+				revealedMoves: ['bravebird'],
+			});
+			const garchomp = mkTracked('Garchomp', {
+				revealedMoves: ['earthquake'],
+				lastMove: 'earthquake',
+			});
+			const bronzScore = evaluateMatchup(bronzong, garchomp, tracker);
+			const skarmScore = evaluateMatchup(skarmory, garchomp, tracker);
+			// Both are immune to EQ via ability/type, so this isn't a
+			// damage delta — the absorb-bonus is what distinguishes them.
+			assert(bronzScore.score >= skarmScore.score - 1,
+				`Levitate Bronzong should be at least as attractive as ` +
+				`Steel/Flying Skarmory into Garchomp (bronz=${bronzScore.score.toFixed(2)}, ` +
+				`skarm=${skarmScore.score.toFixed(2)})`);
+		});
+
+		it('does not bonus an absorb ability when the foe has not revealed a matching move', () => {
+			const tracker = freshTracker();
+			const heatran = mkTracked('Heatran', {
+				ability: 'flashfire',
+				revealedMoves: ['lavaplume'],
+			});
+			const blissey = mkTracked('Blissey', {
+				revealedMoves: ['softboiled'],
+			});
+			const ms = evaluateMatchup(heatran, blissey, tracker);
+			// Score should be a normal matchup, not artificially boosted
+			// by Flash Fire because Blissey has no revealed Fire moves.
+			assert(ms.score < 30,
+				`Flash Fire absorb bonus should NOT apply without a ` +
+				`revealed Fire move on the foe (score=${ms.score.toFixed(2)})`);
+		});
+	});
+
+	// Regression: emergency / dominant-outspeeder checks in the
+	// HeuristicEngine used raw `stats.spe` while the matchup scorer
+	// used `scaledSpeed` (with Swift Swim / Tailwind / Paradox etc).
+	// They are now exported from SwitchEvaluator and the speed predicate
+	// is required to agree across both layers.
+	describe('scaledSpeed exposes weather/paradox/tailwind multipliers', () => {
+		const { scaledSpeed } = require(
+			'../../../../dist/sim/tools/strategic-ai/mechanics/SwitchEvaluator'
+		);
+
+		it('Swift Swim doubles Speed in rain', () => {
+			const barraskewda = mkTracked('Barraskewda', {
+				ability: 'swiftswim',
+				stats: { hp: 286, atk: 348, def: 175, spa: 154, spd: 145, spe: 421 },
+			});
+			const dry = scaledSpeed(barraskewda, false, '');
+			const wet = scaledSpeed(barraskewda, false, 'raindance');
+			assert.equal(wet, dry * 2,
+				`Swift Swim in rain should double Speed ` +
+				`(dry=${dry} wet=${wet})`);
+		});
+
+		it('Chlorophyll doubles Speed in sun', () => {
+			const venusaur = mkTracked('Venusaur', {
+				ability: 'chlorophyll',
+				stats: { hp: 364, atk: 232, def: 247, spa: 290, spd: 287, spe: 246 },
+			});
+			const dry = scaledSpeed(venusaur, false, '');
+			const hot = scaledSpeed(venusaur, false, 'sunnyday');
+			assert.equal(hot, dry * 2,
+				`Chlorophyll in sun should double Speed ` +
+				`(dry=${dry} hot=${hot})`);
+		});
+
+		it('Tailwind doubles Speed regardless of weather', () => {
+			const lugia = mkTracked('Lugia', {
+				stats: { hp: 416, atk: 207, def: 318, spa: 248, spd: 339, spe: 251 },
+			});
+			const noTW = scaledSpeed(lugia, false, '');
+			const yesTW = scaledSpeed(lugia, true, '');
+			assert.equal(yesTW, noTW * 2,
+				`Tailwind should double Speed (noTW=${noTW} yesTW=${yesTW})`);
+		});
+
+		it('Paralysis halves Speed (unless Quick Feet)', () => {
+			const me = mkTracked('Garchomp', {
+				ability: 'roughskin', status: 'par',
+				stats: { hp: 357, atk: 359, def: 246, spa: 222, spd: 237, spe: 333 },
+			});
+			const quick = mkTracked('Linoone', {
+				ability: 'quickfeet', status: 'par',
+				stats: { hp: 281, atk: 248, def: 196, spa: 156, spd: 196, spe: 250 },
+			});
+			const me0 = scaledSpeed(me, false, '');
+			const quick0 = scaledSpeed(quick, false, '');
+			assert(me0 < 333,
+				`Paralysis should halve Speed (got ${me0} for 333 base)`);
+			assert(quick0 > 250,
+				`Quick Feet + status should *raise* Speed (got ${quick0})`);
+		});
+	});
+
+	// Regression: Weakness Policy mons should be willing to "tank a
+	// SE hit on purpose" to trigger the +2 Atk / +2 SpA boost.
+	describe('Weakness Policy bait synergy', () => {
+		it('WP holder scores higher into a foe that has revealed a SE move', () => {
+			const tracker = freshTracker();
+			// Dragonite (Weakness Policy) into a foe with a revealed
+			// Ice attack — WP will trigger from the SE hit.
+			const dragonite = mkTracked('Dragonite', {
+				ability: 'multiscale',
+				item: 'weaknesspolicy',
+				revealedMoves: ['extremespeed', 'dragonclaw'],
+			});
+			const weavile = mkTracked('Weavile', {
+				revealedMoves: ['icepunch'],
+				lastMove: 'icepunch',
+			});
+			const dragonite2 = mkTracked('Dragonite', {
+				ability: 'multiscale',
+				item: 'leftovers',
+				revealedMoves: ['extremespeed', 'dragonclaw'],
+			});
+			const wp = evaluateMatchup(dragonite, weavile, tracker);
+			const leftovers = evaluateMatchup(dragonite2, weavile, tracker);
+			assert(wp.score > leftovers.score + 3,
+				`Weakness Policy Dragonite should score higher into a ` +
+				`revealed Ice attacker than the Leftovers version ` +
+				`(wp=${wp.score.toFixed(2)} lo=${leftovers.score.toFixed(2)})`);
 		});
 	});
 });

--- a/test/sim/tools/strategic-ai/switch-evaluator.js
+++ b/test/sim/tools/strategic-ai/switch-evaluator.js
@@ -179,4 +179,105 @@ describe('Strategic-AI SwitchEvaluator', () => {
 				`+2 Atk Garchomp should score worse than neutral (calm=${calm.score.toFixed(2)} angry=${angry.score.toFixed(2)})`);
 		});
 	});
+
+	// Regression: a monotype Electric team forced to switch into a foe
+	// whose only revealed move is non-Ground used to happily pick a
+	// 4×-weak Ground/Flying teammate. The fix: bestAttackingDamage now
+	// always seeds STAB-type proxies for the foe so unrevealed STAB
+	// threats still register in the matchup math.
+	describe('regression: foe STAB awareness from species', () => {
+		it('prefers a Levitate teammate over a 4× Ground-weak teammate vs a Ground STAB foe', () => {
+			const tracker = freshTracker();
+			// Foe only revealed Dragon Pulse; the AI should still
+			// anticipate Earth Power because Garchomp is Ground-type.
+			const garchomp = mkTracked('Garchomp', {
+				ability: 'roughskin',
+				revealedMoves: ['dragonpulse'],
+			});
+			const magnezone = mkTracked('Magnezone', {
+				ability: 'magnetpull',
+				revealedMoves: ['thunderbolt'],
+			});
+			const rotomFan = mkTracked('Rotom-Fan', {
+				ability: 'levitate',
+				revealedMoves: ['airslash'],
+			});
+
+			const picked = chooseBestSwitch([magnezone, rotomFan], garchomp, tracker);
+			assert(picked, 'should return a chosen mon');
+			assert.equal(picked.mon.species, 'rotomfan',
+				`should prefer Rotom-Fan (Levitate) over 4× Ground-weak Magnezone ` +
+				`(picked ${picked.mon.species})`);
+		});
+
+		it('still notices a 4× weak switch-in when the foe has only revealed one STAB', () => {
+			const tracker = freshTracker();
+			// Foe (Tyranitar) has only revealed Crunch; we should still
+			// be afraid of its Rock STAB because TTar is part-Rock.
+			const ttar = mkTracked('Tyranitar', {
+				ability: 'sandstream',
+				revealedMoves: ['crunch'],
+			});
+			const charizard = mkTracked('Charizard', {
+				ability: 'blaze',
+				revealedMoves: ['flamethrower'],
+			});
+			const result = evaluateMatchup(charizard, ttar, tracker);
+			assert(result.foeDealFraction > 0.7,
+				`Should anticipate STAB Rock threat from Tyranitar even when ` +
+				`unrevealed (got ${result.foeDealFraction.toFixed(2)})`);
+		});
+	});
+
+	// Regression: the AI didn't reward terrain-seed entry synergies, so
+	// it never picked a Grassy Seed holder while Grassy Terrain was up.
+	describe('terrain-seed entry synergy', () => {
+		it('Grassy Seed holder scores higher when Grassy Terrain is active', () => {
+			const trackerNoTerrain = freshTracker();
+			const trackerGrassy = freshTracker();
+			trackerGrassy.field.terrain = 'grassyterrain';
+
+			const foe = mkTracked('Garchomp', {
+				ability: 'roughskin',
+				revealedMoves: ['earthquake'],
+			});
+			const tangrowth = mkTracked('Tangrowth', {
+				ability: 'regenerator',
+				item: 'grassyseed',
+				revealedMoves: ['gigadrain'],
+			});
+
+			const plain = evaluateMatchup(tangrowth, foe, trackerNoTerrain);
+			const synergy = evaluateMatchup(tangrowth, foe, trackerGrassy);
+			assert(synergy.score > plain.score + 5,
+				`Grassy Seed in Grassy Terrain should boost matchup score ` +
+				`(plain=${plain.score.toFixed(2)} synergy=${synergy.score.toFixed(2)})`);
+		});
+
+		it('Intimidate bonus shifts the switch decision toward the physical-foe-counter', () => {
+			const tracker = freshTracker();
+			const garchomp = mkTracked('Garchomp', {
+				ability: 'roughskin',
+				revealedMoves: ['earthquake'],
+				stats: { hp: 357, atk: 359, def: 246, spa: 222, spd: 237, spe: 333 },
+			});
+			// Two roughly comparable defensive answers; one has Intimidate.
+			const landorus = mkTracked('Landorus-Therian', {
+				ability: 'intimidate',
+				item: 'leftovers',
+				revealedMoves: ['earthquake'],
+			});
+			const gliscor = mkTracked('Gliscor', {
+				ability: 'poisonheal',
+				item: 'toxicorb',
+				revealedMoves: ['earthquake'],
+			});
+			const intim = evaluateMatchup(landorus, garchomp, tracker);
+			const plain = evaluateMatchup(gliscor, garchomp, tracker);
+			assert(intim.score > plain.score,
+				`Intimidate should score higher into a physical attacker than ` +
+				`a non-Intimidate equivalent (intim=${intim.score.toFixed(2)} ` +
+				`plain=${plain.score.toFixed(2)})`);
+		});
+	});
 });

--- a/test/sim/tools/strategic-ai/switch-evaluator.js
+++ b/test/sim/tools/strategic-ai/switch-evaluator.js
@@ -228,6 +228,54 @@ describe('Strategic-AI SwitchEvaluator', () => {
 				`Should anticipate STAB Rock threat from Tyranitar even when ` +
 				`unrevealed (got ${result.foeDealFraction.toFixed(2)})`);
 		});
+
+		// Regression: STAB proxies were hardcoded `category: "Physical"`,
+		// so a special-leaning foe (Magnezone) that had only revealed a
+		// non-STAB move was scored off its tiny Attack stat — the AI
+		// massively under-feared its unrevealed special STAB. Proxies are
+		// now emitted in both categories.
+		it('fears a special-leaning foe\'s unrevealed STAB (Magnezone Flash Cannon)', () => {
+			const tracker = freshTracker();
+			// Magnezone (Electric/Steel) has only revealed Thunderbolt;
+			// its Steel STAB is 4× on Aurorus (Rock/Ice) and special.
+			const magnezone = mkTracked('Magnezone', {
+				ability: 'magnetpull',
+				revealedMoves: ['thunderbolt'],
+				stats: { hp: 322, atk: 168, def: 258, spa: 339, spd: 218, spe: 161 },
+			});
+			const aurorus = mkTracked('Aurorus', {
+				ability: 'refrigerate',
+				revealedMoves: ['blizzard'],
+			});
+			const result = evaluateMatchup(aurorus, magnezone, tracker);
+			assert(result.foeDealFraction > 0.6,
+				`Should fear Magnezone's unrevealed special Steel STAB into a ` +
+				`4×-weak Rock/Ice mon (got ${result.foeDealFraction.toFixed(2)})`);
+		});
+
+		// Regression: for our own side `revealedMoves` is seeded complete
+		// from the battle request, so synthesising STAB/coverage proxies
+		// on top overestimated our output. We now use the known set as-is.
+		it('does not invent extra coverage for our own (fully revealed) moveset', () => {
+			const tracker = freshTracker();
+			// Skarmory (Steel/Flying) only carries Brave Bird offensively.
+			// Against Ferrothorn (Steel/Grass) Brave Bird is resisted; the
+			// AI must NOT imagine a coverage Fire move that would be SE.
+			const skarmory = mkTracked('Skarmory', {
+				ability: 'sturdy',
+				revealedMoves: ['bravebird', 'roost', 'spikes', 'whirlwind'],
+			});
+			const ferrothorn = mkTracked('Ferrothorn', {
+				ability: 'ironbarbs',
+				revealedMoves: ['powerwhip'],
+			});
+			const result = evaluateMatchup(skarmory, ferrothorn, tracker);
+			// An invented 4× Fire coverage proxy would push this well
+			// above 0.8; the resisted Brave Bird stays modest.
+			assert(result.weDealFraction < 0.5,
+				`Skarmory should deal little to Ferrothorn — no imagined Fire ` +
+				`coverage (got ${result.weDealFraction.toFixed(2)})`);
+		});
 	});
 
 	// Regression: the AI didn't reward terrain-seed entry synergies, so
@@ -278,6 +326,35 @@ describe('Strategic-AI SwitchEvaluator', () => {
 			assert(intim.score > plain.score,
 				`Intimidate should score higher into a physical attacker than ` +
 				`a non-Intimidate equivalent (intim=${intim.score.toFixed(2)} ` +
+				`plain=${plain.score.toFixed(2)})`);
+		});
+
+		// Regression: Unaware on the foe was wrongly treated as cancelling
+		// Intimidate's bonus. Unaware only ignores the *opponent's* stat
+		// stages during damage calc; the foe still swings with its own
+		// Intimidate-lowered Attack, so the bonus must still apply.
+		it('Intimidate bonus still applies into an Unaware physical attacker', () => {
+			const tracker = freshTracker();
+			const unawareFoe = mkTracked('Garchomp', {
+				ability: 'unaware',
+				revealedMoves: ['earthquake'],
+				stats: { hp: 357, atk: 359, def: 246, spa: 222, spd: 237, spe: 333 },
+			});
+			const landorus = mkTracked('Landorus-Therian', {
+				ability: 'intimidate',
+				item: 'leftovers',
+				revealedMoves: ['earthquake'],
+			});
+			const gliscor = mkTracked('Gliscor', {
+				ability: 'poisonheal',
+				item: 'toxicorb',
+				revealedMoves: ['earthquake'],
+			});
+			const intim = evaluateMatchup(landorus, unawareFoe, tracker);
+			const plain = evaluateMatchup(gliscor, unawareFoe, tracker);
+			assert(intim.score > plain.score,
+				`Intimidate should still out-score a non-Intimidate peer even ` +
+				`when the physical foe has Unaware (intim=${intim.score.toFixed(2)} ` +
 				`plain=${plain.score.toFixed(2)})`);
 		});
 	});
@@ -517,6 +594,19 @@ describe('Strategic-AI SwitchEvaluator', () => {
 			const yesTW = scaledSpeed(lugia, true, '');
 			assert.equal(yesTW, noTW * 2,
 				`Tailwind should double Speed (noTW=${noTW} yesTW=${yesTW})`);
+		});
+
+		it('Quark Drive activates on Electric Terrain set by another source', () => {
+			// Highest stat is Speed, so Quark Drive picks Spe → 1.5×.
+			const ironMon = mkTracked('Iron Valiant', {
+				ability: 'quarkdrive',
+				stats: { hp: 250, atk: 200, def: 150, spa: 200, spd: 150, spe: 300 },
+			});
+			const plain = scaledSpeed(ironMon, false, '', '');
+			const onTerrain = scaledSpeed(ironMon, false, '', 'electricterrain');
+			assert.equal(onTerrain, Math.floor(plain * 1.5),
+				`Quark Drive should give 1.5× Speed on Electric Terrain ` +
+				`(plain=${plain} terrain=${onTerrain})`);
 		});
 
 		it('Paralysis halves Speed (unless Quick Feet)', () => {


### PR DESCRIPTION
Enhance strategic-AI scoring and add regression tests. - HeuristicEngine: add proactive-switch thresholds (PROACTIVE_SWITCH_DELTA/FLOOR) and trigger to avoid flip-flopping on small edges. - MoveEvaluator: special-case Counter/Mirror Coat/Metal Burst, refine Encore scoring, add Destiny Bond and Baton Pass scoring, and minor cleanup (recovery move formatting). - SwitchEvaluator: add entry-synergy bonuses (terrain seeds, Intimidate, weather setters) and improve bestAttackingDamage by seeding STAB proxy moves and conservative coverage probes. - Tests: add comprehensive move-evaluator tests and extend switch-evaluator tests to cover STAB-awareness and terrain/Intimidate synergies. These changes fix AI issues like DB spamming, Baton Pass being undervalued, missed Counter picks, terrain-seed blindspots, and unrevealed-STAB underestimation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Smarter switching: proactive bench-synergy scoring, stronger survivability gating, emergency-switch override, and vetoes when the active benefits from consumables or setup windows.
  * Richer move scoring: improved priority/KO heuristics, dedicated handling for Counter/Mirror Coat/Metal Burst/Sucker Punch, Destiny Bond, Baton Pass, Encore, and hazard/yawn/endure heuristics.
  * Better damage/stat estimates: Paradox/Protosynthesis/Quark Drive and Solar Power now affect damage and speed estimations.
  * Improved AI context: engines now track recent failed moves to inform decisions.

* **Refactor**
  * Targeting and evaluator helpers reorganized for clearer decision logic.

* **Tests**
  * Extensive regression suites added for move, switch, and damage evaluation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes only affect simulator AI heuristics and tests, but the logic is large and battle-decision-sensitive; wrong scoring could change competitive AI behavior noticeably.
> 
> **Overview**
> This PR tightens **strategic-AI** move choice and switching so playtests stop cycling bad pivots, undervaluing key moves, and mis-estimating damage.
> 
> **Switching (`HeuristicEngine` + `SwitchEvaluator`)** adds proactive bench swaps when a teammate clears score floors and a large delta over the active mon, while new **vetoes** block flip-flops: wasted consumable/seed/Paradox boosts, Focus Sash/Sturdy/WP/Unburden setup windows, healthy outspeeders that already pressure the foe, usable priority KOs, sac-into-OHKO bench picks, and “stay and sac” when both active and switch-in would die to the same hit. Emergency speed checks now use exported **`scaledSpeed`** (weather abilities, Tailwind, Trick Room, Quark Drive on terrain). Matchup scoring gains **entry synergies** (seeds, Intimidate, weather speed, Booster Energy, absorb abilities, WP bait) and a **survivability gate**; foe threat modeling seeds **STAB proxies** (both categories) without inventing extra coverage on our full moveset.
> 
> **Move scoring (`MoveEvaluator` + `DamageCalc`)** special-cases Counter/Mirror Coat/Metal Burst, Sucker Punch, Destiny Bond, Baton Pass, Encore, Yawn, Endure, richer priority/hazard/setup logic, and threads **`attackerLastMoveFailed`** for Stomping Tantrum. Damage calc adds conditional BP (Bolt Beak/Payback/Revenge/etc.), **Protosynthesis/Quark Drive** and **Solar Power**, auto-crit for `willCrit` moves, and turn-order hints.
> 
> **State**: `BattleStateTracker` records **`lastMoveFailed`** from miss/immune/fail/cant; `PlayerAI` carries **`lastMoveFailedByMon`** on `EngineContext`. Large **regression tests** cover these behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 433f496ab06adba6534ff4fa9beca34741746223. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->