### PR TITLE
Huge AI Improvements

### DIFF
--- a/data/random-battles/gen8/teams.ts
+++ b/data/random-battles/gen8/teams.ts
@@ -2151,7 +2151,13 @@ export class RandomGen8Teams {
 			// Only change the forme. The species has custom moves, and may have different typing and requirements.
 			return species.battleOnly;
 		}
-		if (species.cosmeticFormes) return this.sample([species.name].concat(species.cosmeticFormes));
+		if (species.cosmeticFormes) {
+			// PokeBedrock event skins are registered as cosmetic formes but
+			// have no dex entries/aliases — only sample formes the dex can
+			// resolve (see gen9 getForme).
+			const formes = [species.name, ...species.cosmeticFormes.filter(forme => this.dex.species.get(forme).exists)];
+			return this.sample(formes);
+		}
 		if (species.name.endsWith('-Gmax')) return species.name.slice(0, -5);
 
 		// Consolidate mostly-cosmetic formes, at least for the purposes of Random Battles

--- a/data/random-battles/gen9/teams.ts
+++ b/data/random-battles/gen9/teams.ts
@@ -1442,7 +1442,14 @@ export class RandomTeams {
 			// Only change the forme. The species has custom moves, and may have different typing and requirements.
 			return species.battleOnly;
 		}
-		if (species.cosmeticFormes) return this.sample([species.name].concat(species.cosmeticFormes));
+		if (species.cosmeticFormes) {
+			// PokeBedrock event skins are registered as cosmetic formes but
+			// have no dex entries/aliases, so sampling them crashes battle
+			// creation ("Unidentified species") — only sample formes the
+			// dex can resolve.
+			const formes = [species.name, ...species.cosmeticFormes.filter(forme => this.dex.species.get(forme).exists)];
+			return this.sample(formes);
+		}
 
 		// Consolidate mostly-cosmetic formes, at least for the purposes of Random Battles
 		if (['Dudunsparce', 'Magearna', 'Maushold', 'Polteageist', 'Sinistcha', 'Zarude'].includes(species.baseSpecies)) {

--- a/data/random-battles/gen9baby/teams.ts
+++ b/data/random-battles/gen9baby/teams.ts
@@ -532,7 +532,13 @@ export class RandomBabyTeams extends RandomTeams {
 			// Only change the forme. The species has custom moves, and may have different typing and requirements.
 			return species.battleOnly;
 		}
-		if (species.cosmeticFormes) return this.sample([species.name].concat(species.cosmeticFormes));
+		if (species.cosmeticFormes) {
+			// PokeBedrock event skins are registered as cosmetic formes but
+			// have no dex entries/aliases — only sample formes the dex can
+			// resolve (see gen9 getForme).
+			const formes = [species.name, ...species.cosmeticFormes.filter(forme => this.dex.species.get(forme).exists)];
+			return this.sample(formes);
+		}
 
 		// Consolidate mostly-cosmetic formes, at least for the purposes of Random Battles
 		if (['Poltchageist', 'Sinistea'].includes(species.baseSpecies)) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pokebedrock-showdown",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pokebedrock-showdown",
-      "version": "0.1.20",
+      "version": "0.1.21",
       "license": "MIT",
       "dependencies": {
         "@minecraft/server": "^2.1.0-beta.1.21.90-stable",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pokebedrock-showdown",
   "description": "A modified version of the Pokémon Showdown server, designed for PokeBedrock.",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "main": "dist/sim/index.js",
   "types": "dist/sim/index.d.ts",
   "dependencies": {

--- a/sim/tools/player-ai.ts
+++ b/sim/tools/player-ai.ts
@@ -13,6 +13,7 @@
  *
  * @license MIT
  */
+import type { Battle } from "../battle";
 import { BattlePlayer } from "../battle-stream";
 import { PRNG, type PRNGSeed } from "../prng";
 import { toID } from "../dex";
@@ -98,11 +99,18 @@ export class PlayerAI extends BattlePlayer {
 			trappedActiveByMon: new Set(),
 			lastSwitchTurnByMon: new Map(),
 			lastMoveFailedByMon: new Set(),
-			noiseEpsilon: 0,
+			switchCount: 0,
+			ladderAdvanceCap: 0.5,
+			switchMargin: 10,
 			infoForgetting: 0,
 			searchBudgetMs: options.searchBudgetMs,
 			randomMoveProb: options.randomMoveProb,
 			randomMegaProb: options.randomMegaProb,
+			// When the host hands us the raw `BattleStream` (PokeBedrock
+			// actors do; runner tooling hands a player sub-stream that
+			// has no `battle` property) the MCTS tier can fork the live
+			// battle for true multi-turn rollouts.
+			getBattle: () => (playerStream as { battle?: Battle | null }).battle ?? null,
 		};
 		applyKnobs(this.engineCtx, this.difficulty);
 		if (options.searchBudgetMs) this.engineCtx.searchBudgetMs = options.searchBudgetMs;
@@ -123,8 +131,7 @@ export class PlayerAI extends BattlePlayer {
 	override receiveLine(line: string): void {
 		if (line?.startsWith("|")) {
 			if (this.tracker) {
-				const event = parseLine(line);
-				if (event) this.tracker.applyEvent(event);
+				this.applyTrackedLine(line);
 			} else if (this.pendingLogLines.length < 1024) {
 				this.pendingLogLines.push(line);
 			}
@@ -146,6 +153,70 @@ export class PlayerAI extends BattlePlayer {
 	}
 
 	/**
+	 * Feed one protocol log line into the battle state tracker without
+	 * dispatching a choice. Hosts that drive {@link receiveRequest}
+	 * manually with delayed dispatch (PokeBedrock's `TrainerActor` /
+	 * `PokemonActor`) MUST call this for every battle log line they
+	 * interpret — without it the tracker only ever sees `|request|`
+	 * JSON, leaving the engines blind to weather, hazards, revealed foe
+	 * moves, boosts, item/ability reveals, and Choice-lock inference.
+	 *
+	 * `|request|` and `|error|` lines are ignored here: hosts deliver
+	 * those through {@link receiveRequest} / {@link receiveError}
+	 * directly, and re-processing a request would dispatch an undelayed
+	 * duplicate choice.
+	 *
+	 * @param line One raw protocol line (starting with `|`).
+	 */
+	ingestLogLine(line: string): void {
+		if (!line?.startsWith("|")) return;
+		if (line.startsWith("|request|") || line.startsWith("|error|")) return;
+		if (this.tracker) {
+			this.applyTrackedLine(line);
+		} else if (this.pendingLogLines.length < 1024) {
+			this.pendingLogLines.push(line);
+		}
+	}
+
+	/**
+	 * Parse and apply one log line to the tracker, then mirror the
+	 * tracker's per-mon `lastMoveFailed` flags onto
+	 * `engineCtx.lastMoveFailedByMon` whenever a fail-relevant event
+	 * was processed (Stomping Tantrum's 2× BP keys off that set).
+	 *
+	 * @param line One raw protocol line (starting with `|`).
+	 */
+	private applyTrackedLine(line: string): void {
+		const tracker = this.tracker;
+		if (!tracker) return;
+		const event = parseLine(line);
+		if (!event) return;
+		tracker.applyEvent(event);
+		switch (event.kind) {
+		case "move":
+		case "miss":
+		case "immune":
+		case "fail":
+		case "cant":
+		case "crit":
+		case "supereffective":
+		case "resisted":
+			this.syncLastMoveFailed();
+		}
+	}
+
+	/** Mirror per-mon `lastMoveFailed` tracker flags into the engine context. */
+	private syncLastMoveFailed(): void {
+		const tracker = this.tracker;
+		if (!tracker) return;
+		const failed = this.engineCtx.lastMoveFailedByMon;
+		for (const mon of tracker.pokemon.values()) {
+			if (mon.lastMoveFailed) failed.add(mon.id);
+			else failed.delete(mon.id);
+		}
+	}
+
+	/**
 	 * Lazily build the tracker. The first request tells us which side
 	 * is "us"; until then we buffer log lines and replay them once the
 	 * tracker exists.
@@ -155,12 +226,9 @@ export class PlayerAI extends BattlePlayer {
 		if (!sideId) return this.tracker;
 		if (!this.tracker) {
 			this.tracker = new BattleStateTracker({ mySide: sideId });
-			for (const line of this.pendingLogLines) {
-				const event = parseLine(line);
-				if (event) this.tracker.applyEvent(event);
-			}
-			this.pendingLogLines.length = 0;
 			this.engineCtx.tracker = this.tracker;
+			for (const line of this.pendingLogLines) this.applyTrackedLine(line);
+			this.pendingLogLines.length = 0;
 		}
 		if (!request.wait) this.tracker.applyRequest(request);
 		return this.tracker;

--- a/sim/tools/selfplay.ts
+++ b/sim/tools/selfplay.ts
@@ -1,0 +1,519 @@
+/**
+ * AI-vs-AI self-play winrate harness.
+ *
+ * Pits two `PlayerAI` configurations against each other over many
+ * battles and reports winrates, so strategic-ai changes can be
+ * validated empirically ("does difficulty 4 actually beat difficulty 2
+ * more than 50% of the time?") instead of by eyeball.
+ *
+ * Sides are swapped every game to cancel any p1/p2 bias, and each game
+ * gets a fresh deterministic seed derived from the run seed so results
+ * are reproducible (independent of how many worker threads ran them).
+ *
+ * Games are distributed across a `worker_threads` pool (default: all
+ * cores minus one) since each battle is independent, synchronous CPU
+ * work — a single-threaded series leaves the rest of the machine idle.
+ *
+ * Usage (after `node build`):
+ *
+ *     node dist/sim/tools/selfplay.js --a 5 --b 3 --games 100
+ *     node dist/sim/tools/selfplay.js --a 4 --b 4 --format gen9randombattle
+ *     node dist/sim/tools/selfplay.js --a 3 --b 1 --games 50 --seed 1234 --jobs 4
+ *
+ * @license MIT
+ */
+
+import * as os from "os";
+import { Worker, isMainThread, parentPort, workerData } from "worker_threads";
+
+import { type ObjectReadWriteStream } from "../../lib/streams";
+import * as BattleStreams from "../battle-stream";
+import { PRNG, type PRNGSeed } from "../prng";
+import type { ChoiceRequest } from "../side";
+import { PlayerAI, type PlayerAIOptions } from "./player-ai";
+
+/** One contender's configuration. */
+export interface ContenderConfig {
+	/** Label used in reporting (defaults to `d<difficulty>`). */
+	name?: string;
+	/** Difficulty 0..5 passed through to {@link PlayerAI}. */
+	difficulty: number;
+	/** Optional search budget override (ms) for OnePly/MCTS tiers. */
+	searchBudgetMs?: number;
+}
+
+/** Options for {@link runSelfPlay}. */
+export interface SelfPlayOptions {
+	a: ContenderConfig;
+	b: ContenderConfig;
+	/** Number of games to play. Defaults to 50. */
+	games?: number;
+	/** Format id. Defaults to `gen9randombattle`. */
+	format?: string;
+	/** Run seed for reproducibility. */
+	seed?: PRNGSeed | null;
+	/** Hard cap on turns before the game is scored a tie. Defaults to 500. */
+	maxTurns?: number;
+	/**
+	 * Wall-clock cap per game in ms. A stalled game (e.g. a rejected
+	 * choice nobody retries) is force-tied after this long, and scored
+	 * as an errored tie if even the force-tie doesn't land. Without it
+	 * a single deadlocked battle drains the event loop and node exits
+	 * mid-series with code 0 and no summary. Defaults to 60000.
+	 */
+	gameTimeoutMs?: number;
+	/**
+	 * Worker threads to spread games across. Defaults to all cores
+	 * minus one. `1` runs everything inline on the main thread.
+	 */
+	jobs?: number;
+	/** Log each game's result line to stdout. */
+	verbose?: boolean;
+}
+
+/** Aggregated results returned by {@link runSelfPlay}. */
+export interface SelfPlayResult {
+	games: number;
+	winsA: number;
+	winsB: number;
+	ties: number;
+	/** Wins for A as a fraction of decisive games. */
+	winrateA: number;
+	avgTurns: number;
+	errors: number;
+}
+
+/**
+ * `PlayerAI` subclass that retries after a rejected choice instead of
+ * stalling the stream. The production host (PokeBedrock) replays via
+ * its interpreter's error handling; standalone streams have nobody to
+ * do that, so without this a single `[Invalid choice]` deadlocks the
+ * game.
+ */
+class SelfPlayAI extends PlayerAI {
+	private lastSeenRequest: ChoiceRequest | null = null;
+	private retriesForRequest = 0;
+	private static readonly MAX_RETRIES = 5;
+
+	override receiveRequest(request: ChoiceRequest): string {
+		this.lastSeenRequest = request;
+		this.retriesForRequest = 0;
+		return super.receiveRequest(request);
+	}
+
+	override receiveError(error: Error): void {
+		super.receiveError(error);
+		// `[Unavailable choice]` is followed by an updated request from
+		// the sim, so only self-retry the truly terminal rejections.
+		if (error.message.startsWith("[Unavailable choice]")) return;
+		const request = this.lastSeenRequest;
+		if (!request || this.retriesForRequest >= SelfPlayAI.MAX_RETRIES) return;
+		this.retriesForRequest++;
+		const choice = super.receiveRequest(request);
+		if (choice) this.choose(choice);
+	}
+}
+
+/** Per-game outcome. */
+interface GameResult {
+	/** `"a"`, `"b"`, or `null` for a tie/aborted game. */
+	winner: "a" | "b" | null;
+	turns: number;
+	errored: boolean;
+	/** First stream error message, when `errored` is set. */
+	errorMessage?: string;
+}
+
+/** Everything a worker needs to play one game. Structured-cloneable. */
+interface WorkerTask {
+	index: number;
+	format: string;
+	aIsP1: boolean;
+	a: ContenderConfig;
+	b: ContenderConfig;
+	/** Per-game seed; AI seeds, battle seed, and retries derive from it. */
+	gameSeed: PRNGSeed;
+	maxTurns: number;
+	gameTimeoutMs: number;
+}
+
+/**
+ * Play a single battle between the two contenders.
+ *
+ * @param format Format id to run.
+ * @param aIsP1 Whether contender A plays as p1 this game.
+ * @param a Contender A's config.
+ * @param b Contender B's config.
+ * @param prng Run-level PRNG used to derive per-game seeds.
+ * @param maxTurns Turn cap before forcing a tie.
+ * @param gameTimeoutMs Wall-clock cap before the game is force-tied.
+ * @returns The winner (by contender), turn count, and error flag.
+ */
+async function playGame(
+	format: string,
+	aIsP1: boolean,
+	a: ContenderConfig,
+	b: ContenderConfig,
+	prng: PRNG,
+	maxTurns: number,
+	gameTimeoutMs: number
+): Promise<GameResult> {
+	const battleStream = new BattleStreams.BattleStream();
+	const streams = BattleStreams.getPlayerStreams(battleStream);
+	// Expose the live battle on the player sub-streams the way the
+	// production host does (it hands `PlayerAI` the raw battle stream),
+	// so the MCTS tier's fork rollouts are exercised in self-play too.
+	for (const sub of [streams.p1, streams.p2]) {
+		Object.defineProperty(sub, "battle", { get: () => battleStream.battle });
+	}
+
+	const newSeed = (): PRNGSeed => [
+		prng.random(2 ** 16), prng.random(2 ** 16),
+		prng.random(2 ** 16), prng.random(2 ** 16),
+	].join(",") as PRNGSeed;
+
+	const makeAI = (
+		stream: ObjectReadWriteStream<string>,
+		config: ContenderConfig
+	) => new SelfPlayAI(stream, {
+		difficulty: config.difficulty,
+		searchBudgetMs: config.searchBudgetMs,
+		seed: newSeed(),
+	} satisfies PlayerAIOptions);
+
+	const p1 = makeAI(streams.p1, aIsP1 ? a : b);
+	const p2 = makeAI(streams.p2, aIsP1 ? b : a);
+	void p1.start().catch(() => {});
+	void p2.start().catch(() => {});
+
+	const p1Name = aIsP1 ? "Contender A" : "Contender B";
+	const p2Name = aIsP1 ? "Contender B" : "Contender A";
+	void streams.omniscient.write(
+		`>start ${JSON.stringify({ formatid: format, seed: newSeed() })}\n` +
+		`>player p1 ${JSON.stringify({ name: p1Name })}\n` +
+		`>player p2 ${JSON.stringify({ name: p2Name })}`
+	);
+
+	let turns = 0;
+	let winnerName: string | null = null;
+	let tie = false;
+	let errored = false;
+	let errorMessage: string | undefined;
+
+	// Stage 1: a stalled battle (rejected choice nobody retried) sits
+	// idle waiting for input — force-tie it so the stream still emits a
+	// result. Stage 2: if even that produces nothing, abandon the game
+	// entirely. Both timers also keep the event loop alive: without
+	// them a deadlocked game makes node exit 0 mid-series.
+	const forceTieTimer = setTimeout(() => {
+		try {
+			void streams.omniscient.write(">forcetie");
+		} catch {}
+	}, gameTimeoutMs);
+	let hangTimer: NodeJS.Timeout | undefined;
+	const hung = new Promise<"hung">(resolve => {
+		hangTimer = setTimeout(() => resolve("hung"), gameTimeoutMs + 5000);
+	});
+
+	const consume = async (): Promise<void> => {
+		for await (const chunk of streams.omniscient) {
+			for (const line of chunk.split("\n")) {
+				if (line.startsWith("|turn|")) {
+					turns = parseInt(line.slice("|turn|".length)) || turns;
+					if (turns >= maxTurns) void streams.omniscient.write(">forcetie");
+				} else if (line.startsWith("|win|")) {
+					winnerName = line.slice("|win|".length).trim();
+				} else if (line === "|tie") {
+					tie = true;
+				}
+			}
+			if (winnerName || tie) break;
+		}
+	};
+
+	try {
+		const raced = await Promise.race([consume(), hung]);
+		if (raced === "hung") {
+			errored = true;
+			errorMessage = `game hung after ${gameTimeoutMs}ms (force-tie ignored)`;
+		}
+	} catch (err) {
+		errored = true;
+		errorMessage = (err as Error).message;
+	} finally {
+		clearTimeout(forceTieTimer);
+		if (hangTimer) clearTimeout(hangTimer);
+	}
+	try {
+		void streams.omniscient.writeEnd();
+	} catch {}
+
+	if (!winnerName) return { winner: null, turns, errored, errorMessage };
+	const winner = winnerName === "Contender A" ? "a" : winnerName === "Contender B" ? "b" : null;
+	return { winner, turns, errored, errorMessage };
+}
+
+/**
+ * Play one game with retries for games that die before turn 1 (e.g.
+ * the random team generator rolled a custom species with incomplete
+ * dex data) — those measure nothing about the AIs, so re-roll them
+ * with the next seed derived from the same game PRNG.
+ *
+ * @param task The game's task description (configs, seed, caps).
+ * @returns The final game result after up to 3 re-rolls.
+ */
+async function playGameWithRetries(task: WorkerTask): Promise<GameResult> {
+	const prng = PRNG.get(task.gameSeed);
+	let result = await playGame(
+		task.format, task.aIsP1, task.a, task.b, prng, task.maxTurns, task.gameTimeoutMs
+	);
+	for (let attempt = 0; result.errored && result.turns === 0 && attempt < 3; attempt++) {
+		result = await playGame(
+			task.format, task.aIsP1, task.a, task.b, prng, task.maxTurns, task.gameTimeoutMs
+		);
+	}
+	return result;
+}
+
+/**
+ * Run a set of game tasks across a `worker_threads` pool. Each worker
+ * plays one game at a time; a crashed worker scores its in-flight game
+ * as an errored tie and is respawned.
+ *
+ * @param tasks The games to play.
+ * @param jobs Pool size (number of concurrent worker threads).
+ * @param onResult Called once per task as results arrive (any order).
+ */
+async function runWithWorkerPool(
+	tasks: WorkerTask[],
+	jobs: number,
+	onResult: (index: number, result: GameResult) => void
+): Promise<void> {
+	let next = 0;
+	const spawn = () => new Worker(__filename, { workerData: { selfPlayWorker: true } });
+	const runOne = (worker: Worker, task: WorkerTask) => new Promise<GameResult>((resolve, reject) => {
+		const onMessage = (msg: { index: number, result: GameResult }) => {
+			cleanup();
+			resolve(msg.result);
+		};
+		const onError = (err: Error) => {
+			cleanup();
+			reject(err);
+		};
+		const cleanup = () => {
+			worker.off("message", onMessage);
+			worker.off("error", onError);
+		};
+		worker.on("message", onMessage);
+		worker.on("error", onError);
+		worker.postMessage(task);
+	});
+
+	const lane = async () => {
+		let worker = spawn();
+		while (next < tasks.length) {
+			const task = tasks[next++];
+			try {
+				onResult(task.index, await runOne(worker, task));
+			} catch (err) {
+				onResult(task.index, {
+					winner: null,
+					turns: 0,
+					errored: true,
+					errorMessage: `worker crashed: ${(err as Error).message}`,
+				});
+				void worker.terminate();
+				worker = spawn();
+			}
+		}
+		await worker.terminate();
+	};
+
+	await Promise.all(Array.from({ length: Math.min(jobs, tasks.length) }, lane));
+}
+
+/**
+ * Run the full self-play series and aggregate results.
+ *
+ * @param options Contenders, game count, format, seed, and verbosity.
+ * @returns Aggregate winrates and stats for the series.
+ */
+export async function runSelfPlay(options: SelfPlayOptions): Promise<SelfPlayResult> {
+	const games = options.games ?? 50;
+	const format = options.format ?? "gen9randombattle";
+	const maxTurns = options.maxTurns ?? 500;
+	const gameTimeoutMs = options.gameTimeoutMs ?? 60_000;
+	const jobs = Math.max(1, options.jobs ?? defaultJobs());
+	const prng = PRNG.get(options.seed ?? null);
+
+	// Pre-derive every game's seed from the run PRNG so results are
+	// reproducible regardless of pool size or completion order.
+	const tasks: WorkerTask[] = [];
+	for (let i = 0; i < games; i++) {
+		tasks.push({
+			index: i,
+			format,
+			aIsP1: i % 2 === 0,
+			a: options.a,
+			b: options.b,
+			gameSeed: [
+				prng.random(2 ** 16), prng.random(2 ** 16),
+				prng.random(2 ** 16), prng.random(2 ** 16),
+			].join(",") as PRNGSeed,
+			maxTurns,
+			gameTimeoutMs,
+		});
+	}
+
+	let winsA = 0;
+	let winsB = 0;
+	let ties = 0;
+	let errors = 0;
+	let totalTurns = 0;
+	let completed = 0;
+
+	const record = (index: number, result: GameResult) => {
+		completed++;
+		totalTurns += result.turns;
+		if (result.errored) errors++;
+		if (result.winner === "a") winsA++;
+		else if (result.winner === "b") winsB++;
+		else ties++;
+		if (options.verbose) {
+			const tag = result.winner === "a" ? nameOf(options.a, "A") :
+				result.winner === "b" ? nameOf(options.b, "B") : "tie";
+			console.log(`[${completed}/${games}] game ${index + 1}: ${tag} in ${result.turns} turns` +
+				`${result.errored ? ` (errored: ${result.errorMessage})` : ""}`);
+		}
+	};
+
+	if (jobs === 1) {
+		for (const task of tasks) record(task.index, await playGameWithRetries(task));
+	} else {
+		await runWithWorkerPool(tasks, jobs, record);
+	}
+
+	const decisive = winsA + winsB;
+	return {
+		games,
+		winsA,
+		winsB,
+		ties,
+		winrateA: decisive > 0 ? winsA / decisive : 0.5,
+		avgTurns: games > 0 ? totalTurns / games : 0,
+		errors,
+	};
+}
+
+/**
+ * Default worker-pool size: all cores minus one, so the machine stays
+ * responsive while a series runs.
+ *
+ * @returns The default number of worker threads.
+ */
+function defaultJobs(): number {
+	const cores: number = (os as { availableParallelism?: () => number }).availableParallelism?.() ??
+		os.cpus().length;
+	return Math.max(1, cores - 1);
+}
+
+/**
+ * Display name for a contender.
+ *
+ * @param config The contender config.
+ * @param fallbackTag `"A"` or `"B"`, used when no name is set.
+ * @returns The label used in CLI output.
+ */
+function nameOf(config: ContenderConfig, fallbackTag: string): string {
+	return config.name ?? `${fallbackTag}(d${config.difficulty})`;
+}
+
+/**
+ * Parse `--flag value` style CLI arguments.
+ *
+ * @param argv Raw argv slice (no node/script entries).
+ * @returns Flag-to-value map; bare flags map to `"true"`.
+ */
+function parseArgs(argv: string[]): Record<string, string> {
+	const args: Record<string, string> = {};
+	for (let i = 0; i < argv.length; i++) {
+		const arg = argv[i];
+		if (!arg.startsWith("--")) continue;
+		const key = arg.slice(2);
+		const next = argv[i + 1];
+		if (next && !next.startsWith("--")) {
+			args[key] = next;
+			i++;
+		} else {
+			args[key] = "true";
+		}
+	}
+	return args;
+}
+
+// Worker-thread entry: play games sent from the main thread's pool.
+if (!isMainThread && (workerData as { selfPlayWorker?: boolean } | null)?.selfPlayWorker) {
+	parentPort!.on("message", (task: WorkerTask) => {
+		playGameWithRetries(task)
+			.then(result => parentPort!.postMessage({ index: task.index, result }))
+			.catch((err: Error) => parentPort!.postMessage({
+				index: task.index,
+				result: {
+					winner: null,
+					turns: 0,
+					errored: true,
+					errorMessage: err.message,
+				} satisfies GameResult,
+			}));
+	});
+}
+
+if (require.main === module && isMainThread) {
+	const args = parseArgs(process.argv.slice(2));
+	if (args.help) {
+		console.log(
+			`Usage: node dist/sim/tools/selfplay.js [options]\n` +
+			`  --a <0..5>        Contender A difficulty (default 3)\n` +
+			`  --b <0..5>        Contender B difficulty (default 1)\n` +
+			`  --games <n>       Games to play (default 50)\n` +
+			`  --format <id>     Format id (default gen9randombattle)\n` +
+			`  --seed <n,n,n,n>  Run seed for reproducibility\n` +
+			`  --budget-a <ms>   Search budget override for A\n` +
+			`  --budget-b <ms>   Search budget override for B\n` +
+			`  --max-turns <n>   Turn cap per game (default 500)\n` +
+			`  --game-timeout <ms>  Wall-clock cap per game before force-tie (default 60000)\n` +
+			`  --jobs <n>        Worker threads (default: cores - 1; 1 = inline)\n` +
+			`  --quiet           Suppress per-game lines`
+		);
+		process.exit(0);
+	}
+	const options: SelfPlayOptions = {
+		a: {
+			difficulty: parseInt(args.a ?? "3"),
+			searchBudgetMs: args["budget-a"] ? parseInt(args["budget-a"]) : undefined,
+		},
+		b: {
+			difficulty: parseInt(args.b ?? "1"),
+			searchBudgetMs: args["budget-b"] ? parseInt(args["budget-b"]) : undefined,
+		},
+		games: args.games ? parseInt(args.games) : undefined,
+		format: args.format,
+		seed: (args.seed as PRNGSeed | undefined) ?? null,
+		maxTurns: args["max-turns"] ? parseInt(args["max-turns"]) : undefined,
+		gameTimeoutMs: args["game-timeout"] ? parseInt(args["game-timeout"]) : undefined,
+		jobs: args.jobs ? parseInt(args.jobs) : undefined,
+		verbose: !args.quiet,
+	};
+	void runSelfPlay(options).then(result => {
+		const aLabel = nameOf(options.a, "A");
+		const bLabel = nameOf(options.b, "B");
+		console.log(`\n=== Self-play: ${aLabel} vs ${bLabel} (${options.format ?? "gen9randombattle"}) ===`);
+		console.log(`games:    ${result.games}`);
+		console.log(`${aLabel} wins: ${result.winsA}`);
+		console.log(`${bLabel} wins: ${result.winsB}`);
+		console.log(`ties:     ${result.ties}${result.errors ? `  (errors: ${result.errors})` : ""}`);
+		console.log(`winrate ${aLabel}: ${(result.winrateA * 100).toFixed(1)}% of decisive games`);
+		console.log(`avg turns: ${result.avgTurns.toFixed(1)}`);
+		process.exit(0);
+	});
+}

--- a/sim/tools/selfplay.ts
+++ b/sim/tools/selfplay.ts
@@ -183,8 +183,17 @@ async function playGame(
 
 	const p1 = makeAI(streams.p1, aIsP1 ? a : b);
 	const p2 = makeAI(streams.p2, aIsP1 ? b : a);
-	void p1.start().catch(() => {});
-	void p2.start().catch(() => {});
+	// A crashed AI loop is the only signal that a game is unwinnable; surface
+	// it immediately instead of waiting for the force-tie/hang timers. A
+	// *successful* `start()` resolves at battle end (possibly before `consume`
+	// reads `|win|`), so success maps to a never-settling promise and can't
+	// win the race — only a rejection produces a value.
+	const onlyOnFailure = (p: Promise<void>, side: string) =>
+		p.then(() => new Promise<never>(() => {}), (err: Error) => ({ side, err }));
+	const aiFailure = Promise.race([
+		onlyOnFailure(p1.start(), "p1"),
+		onlyOnFailure(p2.start(), "p2"),
+	]);
 
 	const p1Name = aIsP1 ? "Contender A" : "Contender B";
 	const p2Name = aIsP1 ? "Contender B" : "Contender A";
@@ -232,10 +241,13 @@ async function playGame(
 	};
 
 	try {
-		const raced = await Promise.race([consume(), hung]);
+		const raced = await Promise.race([consume(), hung, aiFailure]);
 		if (raced === "hung") {
 			errored = true;
 			errorMessage = `game hung after ${gameTimeoutMs}ms (force-tie ignored)`;
+		} else if (raced && typeof raced === "object") {
+			errored = true;
+			errorMessage = `${raced.side} AI failed: ${raced.err.message}`;
 		}
 	} catch (err) {
 		errored = true;
@@ -300,12 +312,21 @@ async function runWithWorkerPool(
 			cleanup();
 			reject(err);
 		};
+		// A worker can die (OOM, process.exit) without ever emitting "error";
+		// without this the lane would hang forever instead of erroring the
+		// game and respawning the worker.
+		const onExit = (code: number) => {
+			cleanup();
+			reject(new Error(`worker exited before replying (code ${code})`));
+		};
 		const cleanup = () => {
 			worker.off("message", onMessage);
 			worker.off("error", onError);
+			worker.off("exit", onExit);
 		};
 		worker.on("message", onMessage);
 		worker.on("error", onError);
+		worker.on("exit", onExit);
 		worker.postMessage(task);
 	});
 
@@ -487,21 +508,39 @@ if (require.main === module && isMainThread) {
 		);
 		process.exit(0);
 	}
+	// Reject NaN / out-of-range numeric flags up front with a clear usage
+	// error instead of letting them flow into runSelfPlay() as empty runs,
+	// immediate timeouts, or invalid difficulty configs.
+	const intArg = (
+		raw: string | undefined,
+		name: string,
+		min: number,
+		max = Infinity
+	): number | undefined => {
+		if (raw === undefined) return undefined;
+		const n = Number(raw);
+		if (!Number.isInteger(n) || n < min || n > max) {
+			const range = max === Infinity ? `>= ${min}` : `${min}..${max}`;
+			console.error(`Invalid --${name}: "${raw}" (expected integer ${range})`);
+			process.exit(1);
+		}
+		return n;
+	};
 	const options: SelfPlayOptions = {
 		a: {
-			difficulty: parseInt(args.a ?? "3"),
-			searchBudgetMs: args["budget-a"] ? parseInt(args["budget-a"]) : undefined,
+			difficulty: intArg(args.a, "a", 0, 5) ?? 3,
+			searchBudgetMs: intArg(args["budget-a"], "budget-a", 0),
 		},
 		b: {
-			difficulty: parseInt(args.b ?? "1"),
-			searchBudgetMs: args["budget-b"] ? parseInt(args["budget-b"]) : undefined,
+			difficulty: intArg(args.b, "b", 0, 5) ?? 1,
+			searchBudgetMs: intArg(args["budget-b"], "budget-b", 0),
 		},
-		games: args.games ? parseInt(args.games) : undefined,
+		games: intArg(args.games, "games", 1),
 		format: args.format,
 		seed: (args.seed as PRNGSeed | undefined) ?? null,
-		maxTurns: args["max-turns"] ? parseInt(args["max-turns"]) : undefined,
-		gameTimeoutMs: args["game-timeout"] ? parseInt(args["game-timeout"]) : undefined,
-		jobs: args.jobs ? parseInt(args.jobs) : undefined,
+		maxTurns: intArg(args["max-turns"], "max-turns", 1),
+		gameTimeoutMs: intArg(args["game-timeout"], "game-timeout", 0),
+		jobs: intArg(args.jobs, "jobs", 1),
 		verbose: !args.quiet,
 	};
 	void runSelfPlay(options).then(result => {

--- a/sim/tools/strategic-ai/engines/Engine.ts
+++ b/sim/tools/strategic-ai/engines/Engine.ts
@@ -19,6 +19,7 @@
  *
  * @license MIT
  */
+import type { Battle } from "../../../battle";
 import type { PRNG } from "../../../prng";
 import type { ChoiceRequest } from "../../../side";
 import type { BattleStateTracker } from "../state/BattleStateTracker";
@@ -39,11 +40,12 @@ export interface EngineContext {
 	/** Per-Pokemon disabled-move sets (Imprison/Disable). */
 	disabledMovesByMon: Map<string, Set<string>>;
 	/**
-	 * Per-Pokemon "did the previous move attempt fail" flag, set by
-	 * {@link PlayerAI.receiveLine} when a `|miss|`, `|-immune|`, or
-	 * `|cant|` line is parsed against that mon. Cleared the next time
-	 * the same mon successfully uses a move. Used by power-doubling
-	 * moves like Stomping Tantrum (2× BP when the user's previous move
+	 * Per-Pokemon "did the previous move attempt fail" flag, mirrored
+	 * from the tracker by `PlayerAI` whenever a `|miss|`, `|-immune|`,
+	 * `|-fail|`, or `|cant|` line is parsed against that mon (via
+	 * `receiveLine` or `ingestLogLine`). Cleared the next time the
+	 * same mon successfully uses a move. Used by power-doubling moves
+	 * like Stomping Tantrum (2× BP when the user's previous move
 	 * failed).
 	 */
 	lastMoveFailedByMon: Set<string>;
@@ -61,11 +63,26 @@ export interface EngineContext {
 	/** Per-Pokemon last switch turn. */
 	lastSwitchTurnByMon: Map<string, number>;
 	/**
-	 * Epsilon-greedy noise probability. With probability `noiseEpsilon`
-	 * the engine picks a uniformly-random alternative from its
-	 * candidate set instead of the top-scored option. 0 disables noise.
+	 * Net "how often have we been switching lately" counter, pokerogue
+	 * style: incremented each time the engine emits a voluntary switch,
+	 * decremented (floored at 0) each time it commits to a move. The
+	 * switch gate adds a margin penalty proportional to this counter so
+	 * the AI can't ping-pong between two mons.
 	 */
-	noiseEpsilon: number;
+	switchCount: number;
+	/**
+	 * Cap on the per-step advance probability of the move-selection
+	 * ladder (see {@link selectByScoreLadder}). 0 means always-greedy;
+	 * 0.5 is the pokerogue default ("at most a coin flip to slip to
+	 * the next-best move").
+	 */
+	ladderAdvanceCap: number;
+	/**
+	 * Extra matchup-score margin the best bench mon must clear over the
+	 * active mon before a voluntary (non-emergency) switch fires. Lower
+	 * = switch-happier. Scaled per difficulty by `DifficultyPolicy`.
+	 */
+	switchMargin: number;
 	/**
 	 * For low-difficulty engines: probability to "forget" any single
 	 * piece of revealed info (a foe's revealed move, a known item, ...)
@@ -85,6 +102,14 @@ export interface EngineContext {
 	 * when available. Defaults to 0.
 	 */
 	randomMegaProb?: number;
+	/**
+	 * Optional accessor for the live simulator {@link Battle} this AI
+	 * is embedded in. When the host stream is a `BattleStream` the
+	 * shell wires this up automatically, letting the MCTS tier fork
+	 * the real battle (`Battle.toJSON` / `Battle.fromJSON`) for its
+	 * rollouts instead of the tracker-only approximation.
+	 */
+	getBattle?: () => Battle | null;
 }
 
 /**
@@ -102,25 +127,43 @@ export interface Engine {
 	choose(request: ChoiceRequest, ctx: EngineContext): string;
 }
 
-/** Pick a random element from `arr` using `prng`. */
-export function sampleArray<T>(arr: T[], prng: PRNG): T {
-	return arr[Math.floor(prng.random() * arr.length)];
-}
-
 /**
- * Apply epsilon-greedy noise: with probability `epsilon` returns a
- * uniformly-random element from `candidates`; otherwise returns
- * `bestPick`. If `candidates` is empty, returns `bestPick` unmodified.
+ * Pokerogue-style weighted pick ladder over a descending-sorted score
+ * list. Starting from `startIndex`, we advance from candidate `i` to
+ * `i + 1` with probability `min(advanceCap, ratio * advanceCap)` where
+ * `ratio` is how close the next score is to the current one (1 for a
+ * tie, smaller as the next candidate falls behind). The walk stops at
+ * the first failed roll, a score sign flip, or the end of the list.
+ *
+ * This replaces the old epsilon-uniform noise: variety is now
+ * *strength-preserving* — a close second is a frequent pick, a distant
+ * third is rare, and a negative-scored move is never reached from a
+ * positive run.
+ *
+ * @param sorted Candidates sorted by descending score.
+ * @param startIndex Index to start the walk from.
+ * @param advanceCap Maximum per-step advance probability in [0, 1].
+ * @param prng PRNG used for the advance rolls.
+ * @returns The selected candidate. `sorted` must be non-empty.
  */
-export function applyNoise<T>(
-	bestPick: T,
-	candidates: T[],
-	epsilon: number,
+export function selectByScoreLadder<T extends { score: number }>(
+	sorted: T[],
+	startIndex: number,
+	advanceCap: number,
 	prng: PRNG
 ): T {
-	if (epsilon <= 0 || candidates.length <= 1) return bestPick;
-	if (prng.random() >= epsilon) return bestPick;
-	const alternatives = candidates.filter(c => c !== bestPick);
-	if (!alternatives.length) return bestPick;
-	return sampleArray(alternatives, prng);
+	let idx = Math.max(0, Math.min(startIndex, sorted.length - 1));
+	if (advanceCap <= 0) return sorted[idx];
+	while (idx + 1 < sorted.length) {
+		const cur = sorted[idx].score;
+		const next = sorted[idx + 1].score;
+		if (Math.sign(cur) !== Math.sign(next)) break;
+		// Closeness ratio in (0, 1]: works for both positive and
+		// negative same-sign runs because the list is sorted descending.
+		const ratio = cur === next ? 1 : cur > 0 ? next / cur : cur / next;
+		if (!(ratio > 0)) break;
+		if (prng.random() >= Math.min(advanceCap, ratio * advanceCap)) break;
+		idx++;
+	}
+	return sorted[idx];
 }

--- a/sim/tools/strategic-ai/engines/HeuristicEngine.ts
+++ b/sim/tools/strategic-ai/engines/HeuristicEngine.ts
@@ -35,14 +35,14 @@ import { chooseBestSwitch, evaluateMatchup, scaledSpeed } from "../mechanics/Swi
 import { pickTarget } from "../mechanics/TargetPicker";
 import { chooseTransform } from "../mechanics/TransformPolicy";
 import type { BattleStateTracker, TrackedPokemon } from "../state/BattleStateTracker";
-import { applyNoise, type Engine, type EngineContext } from "./Engine";
+import { selectByScoreLadder, type Engine, type EngineContext } from "./Engine";
 
 /** Switch-out HP threshold below which we consider safe-pivoting. */
 const HP_SWITCH_OUT_THRESHOLD = 0.3;
 /** Faint-emergency HP threshold (combine with foe-faster check). */
 const FAINT_THRESHOLD = 0.1;
 /** How many turns we lock against re-switching the same mon. */
-const SWITCH_LOCK_TURNS = 2;
+export const SWITCH_LOCK_TURNS = 2;
 /** Chance per-turn to consider Protect when it's available and safe. */
 const PROTECT_CONSIDER_CHANCE = 0.15;
 /** Switch-out matchup threshold; below this, switching is favoured. */
@@ -69,6 +69,27 @@ const CONDITIONAL_PRIORITY_MOVES = new Set([
 	"firstimpression",
 	"suckerpunch",
 ]);
+/**
+ * Extra matchup margin added per recent switch (see
+ * `EngineContext.switchCount`). Damps switch-loops, pokerogue-style:
+ * each voluntary switch raises the bar for the next one until the AI
+ * commits to a few moves again.
+ */
+const SWITCH_FREQUENCY_MARGIN = 6;
+/** Cap on the accumulated switch-frequency counter. */
+const SWITCH_COUNT_CAP = 4;
+/**
+ * "Disciplined play" gate: at low ladder caps (difficulty 4-5) the
+ * deliberate noise sources — the random Protect probe and the
+ * anti-staleness move rotation — are pure handicaps, so they're
+ * disabled. Mid/low tiers keep them for human-feeling variety.
+ *
+ * @param ctx Engine context carrying the difficulty knobs.
+ * @returns true when noise sources should be suppressed.
+ */
+function isDisciplined(ctx: EngineContext): boolean {
+	return ctx.ladderAdvanceCap <= 0.3;
+}
 
 /** Lazy `Dex.moves.get`. */
 function moveOf(id: string) {
@@ -95,6 +116,18 @@ const TRANSFORM_SUFFIX_CLAIMS: Record<string, "mega" | "ultra" | "dynamax" | "te
 	" terastallize": "tera",
 	" zmove": "zmove",
 };
+
+/**
+ * Cross-slot signals shared while deciding a multi-active (doubles /
+ * triples) turn. Slots decide left-to-right, so later slots can react
+ * to what earlier slots already committed to.
+ */
+interface TurnPlan {
+	/** An earlier slot chose Helping Hand this turn. */
+	helpingHand: boolean;
+	/** An earlier slot chose a damaging move this turn. */
+	partnerAttacks: boolean;
+}
 
 /**
  * Default heuristic engine. Stateless (state lives on `EngineContext`).
@@ -236,10 +269,15 @@ export class HeuristicEngine implements Engine {
 		if (!side || !request.active || !tracker) return "default";
 
 		const transformsUsed: TransformClaims = new Set();
+		// Cross-slot signals for doubles: slots decide in order, so a
+		// later slot can see that an earlier one picked Helping Hand
+		// (target-damage boost) or a damaging move (Assurance's
+		// "already took damage this turn" doubling).
+		const turnPlan: TurnPlan = { helpingHand: false, partnerAttacks: false };
 		const decisions: string[] = request.active.map((active, slotIndex) => {
 			const sideMon = side.pokemon[slotIndex];
 			if (!sideMon || sideMon.condition.endsWith(" fnt")) return "pass";
-			return this.decideForSlot(request, ctx, tracker, slotIndex, active, transformsUsed);
+			return this.decideForSlot(request, ctx, tracker, slotIndex, active, transformsUsed, turnPlan);
 		});
 		return decisions.join(", ");
 	}
@@ -250,7 +288,8 @@ export class HeuristicEngine implements Engine {
 		tracker: BattleStateTracker,
 		slotIndex: number,
 		active: PokemonMoveRequestData,
-		transformsUsed: TransformClaims
+		transformsUsed: TransformClaims,
+		turnPlan: TurnPlan
 	): string {
 		const side = request.side;
 		const sideMon = side.pokemon[slotIndex];
@@ -276,6 +315,7 @@ export class HeuristicEngine implements Engine {
 			);
 			if (switchDecision) {
 				if (monId) ctx.lastSwitchTurnByMon.set(monId, tracker.turn);
+				ctx.switchCount = Math.min(SWITCH_COUNT_CAP, ctx.switchCount + 1);
 				return switchDecision;
 			}
 		}
@@ -284,11 +324,13 @@ export class HeuristicEngine implements Engine {
 		const availableMoves = this.availableMoves(active, monId, ctx);
 		if (!availableMoves.length) return "default";
 
-		// 3. Optional Protect probe.
-		if (lastMoveId !== "protect" && ctx.prng.random() < PROTECT_CONSIDER_CHANCE) {
+		// 3. Optional Protect probe (suppressed at disciplined tiers —
+		// the move evaluator already scores Protect on its merits).
+		if (!isDisciplined(ctx) && lastMoveId !== "protect" && ctx.prng.random() < PROTECT_CONSIDER_CHANCE) {
 			const protectIdx = availableMoves.findIndex(m => m.id === "protect");
 			if (protectIdx >= 0) {
 				if (monId) ctx.lastMoveByMon.set(monId, "protect");
+				ctx.switchCount = Math.max(0, ctx.switchCount - 1);
 				return `move ${this.moveCommandIndex(active, "protect")}`;
 			}
 		}
@@ -308,7 +350,11 @@ export class HeuristicEngine implements Engine {
 			// Plumb "did our last attempt fizzle?" through to the move
 			// scorer. This lets Stomping Tantrum's 2× BP fire after
 			// e.g. an Earthquake into Levitate the previous turn.
-			attackerLastMoveFailed: myMon.lastMoveFailed,
+			attackerLastMoveFailed: myMon.lastMoveFailed ||
+				ctx.lastMoveFailedByMon.has(myMon.id),
+			// Doubles partner combo: an earlier slot already committed
+			// to a damaging move this turn (Assurance 2× BP).
+			defenderTookDamageThisTurn: turnPlan.partnerAttacks,
 		};
 
 		const scored = this.scoreCandidates(availableMoves, evalCtx, ctx);
@@ -316,31 +362,49 @@ export class HeuristicEngine implements Engine {
 
 		// 5. Anti-staleness: avoid repeating the same move turn-after-turn
 		// when an alternative is nearly as good (predictability hurts).
-		let pick = scored[0];
+		// Suppressed at disciplined tiers: repeating the best move is
+		// usually correct, and with a greedy ladder this rule would
+		// *always* demote it.
+		let startIndex = 0;
 		if (
+			!isDisciplined(ctx) &&
 			scored.length > 1 &&
-			pick.opt.id === lastMoveId &&
-			scored[1].score >= 0.9 * pick.score
+			scored[0].opt.id === lastMoveId &&
+			scored[1].score >= 0.9 * scored[0].score
 		) {
-			pick = scored[1];
+			startIndex = 1;
 		}
-		// 6. Apply epsilon noise.
-		const noisedPool = scored.filter(s => s.score >= pick.score * 0.5);
-		const noised = applyNoise(pick, noisedPool, ctx.noiseEpsilon, ctx.prng);
-		const chosen = noised.opt;
+		// 6. Pokerogue-style pick ladder: walk down the sorted list,
+		// advancing with probability proportional to score closeness
+		// (capped per difficulty — difficulty 5 is near-greedy).
+		const chosen = selectByScoreLadder(scored, startIndex, ctx.ladderAdvanceCap, ctx.prng).opt;
 		if (monId) ctx.lastMoveByMon.set(monId, chosen.id);
+		ctx.switchCount = Math.max(0, ctx.switchCount - 1);
+		if (chosen.id === "helpinghand") turnPlan.helpingHand = true;
+		else if (moveOf(chosen.id)?.category !== "Status") turnPlan.partnerAttacks = true;
 
 		// 7. Format command (with target for doubles).
 		return this.formatMoveCommand(
-			active, chosen.id, slotIndex, request, ctx, tracker, myMon, transformsUsed
+			active, chosen.id, slotIndex, request, ctx, tracker, myMon, transformsUsed, turnPlan
 		);
 	}
 
 	/**
-	 * Evaluate whether the active mon should switch this turn. Returns a
-	 * `switch N` command or `null` to indicate "stay in".
+	 * Evaluate whether the active mon should switch this turn. Protected
+	 * so search engines can wrap it (e.g. {@link MctsEngine} verifies or
+	 * overrides the verdict with fork rollouts).
+	 *
+	 * @param myMon Tracked active mon for this slot.
+	 * @param foeMon Tracked foe active.
+	 * @param tracker Battle state tracker.
+	 * @param side Our side's request payload.
+	 * @param slotIndex Slot being decided.
+	 * @param ctx Engine context.
+	 * @param switchCandidates Live bench candidates with request slots.
+	 * @param active Request payload for the active slot.
+	 * @returns A `switch N` command, or `null` to indicate "stay in".
 	 */
-	private maybeSwitchOut(
+	protected maybeSwitchOut(
 		myMon: TrackedPokemon,
 		foeMon: TrackedPokemon,
 		tracker: BattleStateTracker,
@@ -466,9 +530,19 @@ export class HeuristicEngine implements Engine {
 		if (!candidateSurvives && !isEmergency) return null;
 		const slot = switchCandidates.find(c => c.mon.id === best.mon.id);
 		if (!slot) return null;
-		// Skill-gated: lower difficulty switches less reliably.
-		const skill = Math.max(0, Math.min(1, (ctx.difficulty - 1) / 4));
-		if (ctx.prng.random() > skill) return null;
+		// Margin gate (pokerogue-style), replacing the old
+		// `(difficulty - 1) / 4` coin flip that made even elite trainers
+		// ignore half of their correct switches at difficulty 3 and
+		// added pure noise at 4-5. A voluntary switch must now beat the
+		// current matchup by a difficulty-scaled margin, raised further
+		// the more we've been switching lately so the AI can't
+		// switch-loop. Emergencies are exempt — staying in is strictly
+		// worse no matter the margin.
+		if (!emergencySwitch) {
+			const requiredMargin = ctx.switchMargin +
+				ctx.switchCount * SWITCH_FREQUENCY_MARGIN;
+			if (bestScore - matchup.score < requiredMargin) return null;
+		}
 		return `switch ${slot.idx}`;
 	}
 
@@ -617,7 +691,8 @@ export class HeuristicEngine implements Engine {
 		ctx: EngineContext,
 		tracker: BattleStateTracker,
 		myMon: TrackedPokemon,
-		transformsUsed: TransformClaims
+		transformsUsed: TransformClaims,
+		turnPlan: TurnPlan
 	): string {
 		const idx = this.moveCommandIndex(active, moveId);
 		// Decide whether to consume a one-shot transformation (Tera/
@@ -669,6 +744,7 @@ export class HeuristicEngine implements Engine {
 				move,
 				foeSlots: foeSlotMons,
 				allySlots: allyMons,
+				allyUsedHelpingHand: turnPlan.helpingHand,
 			});
 			return t !== null ? `move ${idx} ${t}${suffix}` : `move ${idx}${suffix}`;
 		}
@@ -685,7 +761,7 @@ export class HeuristicEngine implements Engine {
 		}
 	}
 
-	private monIdForSlot(
+	protected monIdForSlot(
 		side: SideRequestData,
 		slotIndex: number,
 		ctx: EngineContext

--- a/sim/tools/strategic-ai/engines/MctsEngine.ts
+++ b/sim/tools/strategic-ai/engines/MctsEngine.ts
@@ -27,12 +27,24 @@
  *
  * @license MIT
  */
+import { Battle } from "../../../battle";
 import { Dex } from "../../../dex";
 import type { Move } from "../../../dex-moves";
+import type { Pokemon } from "../../../pokemon";
+import { PRNG, type PRNGSeed } from "../../../prng";
+import type {
+	PokemonMoveRequestData,
+	PokemonSwitchRequestData,
+	Side,
+	SideRequestData,
+} from "../../../side";
 import { calculateDamage, fromTracked } from "../mechanics/DamageCalc";
 import { evaluateMove, type MoveEvalContext } from "../mechanics/MoveEvaluator";
+import { chooseBestSwitch, evaluateMatchup } from "../mechanics/SwitchEvaluator";
+import type { BattleStateTracker, TrackedPokemon } from "../state/BattleStateTracker";
 import { inferFoeActive, topMoves } from "../state/OpponentInference";
 import type { EngineContext } from "./Engine";
+import { SWITCH_LOCK_TURNS } from "./HeuristicEngine";
 import { OnePlySearchEngine } from "./OnePlySearchEngine";
 
 /** Default search budget in milliseconds when not provided by ctx. */
@@ -43,6 +55,71 @@ const MIN_VISITS_PER_CANDIDATE = 4;
 const C_PUCT = 1.4;
 /** Top-N foe replies to sample per rollout. */
 const FOE_SAMPLE_N = 4;
+/** Wider inferred-move pool used to determinize foe move slots. */
+const DETERMINIZE_POOL_N = 8;
+/** Extra turns played out per fork rollout after the root turn. */
+const FORK_ROLLOUT_TURNS = 2;
+/** Reward scale converting fork HP-differential swings into MoveEvaluator units. */
+const FORK_REWARD_SCALE = 35;
+/** Flat bonus/penalty when a fork rollout ends the battle. */
+const FORK_WIN_BONUS = 60;
+/**
+ * Maximum weight the (noisy) rollout estimate can carry in the final
+ * blended score; the rest stays on the heuristic baseline. Rollouts
+ * against determinized (guessed) foe sets are high-variance in random
+ * formats, so they act as a tiebreaker rather than overriding the
+ * heuristic outright.
+ */
+const ROLLOUT_MAX_WEIGHT = 0.6;
+/** Visit count at which the rollout estimate reaches half its max weight. */
+const ROLLOUT_HALF_WEIGHT_VISITS = 6;
+/**
+ * Probability the foe's root reply in a fork rollout is its greedy
+ * max-damage move (on the determinized set) rather than a prior
+ * sample. Real opponents — including our own lower tiers — play
+ * near-greedy, so a mostly-greedy foe model is tougher and lower
+ * variance than pure prior sampling.
+ */
+const GREEDY_FOE_REPLY_CHANCE = 0.65;
+/** Fork-eval penalty per non-volatile status on a living mon. */
+const STATUS_EVAL_PENALTY = 0.12;
+/** Fork-eval value per net stat-boost stage on an active mon. */
+const BOOST_EVAL_VALUE = 0.04;
+/** Max fork rollouts per arm of a stay-vs-switch comparison. */
+const SWITCH_EVAL_ROLLOUTS = 5;
+/** Fraction of the search budget the switch comparison may consume. */
+const SWITCH_EVAL_BUDGET_FRACTION = 0.35;
+/**
+ * Reward margin by which "stay" must beat a heuristic-proposed switch
+ * before the search vetoes it (rewards are ~35 per mon of HP swing).
+ */
+const SWITCH_VETO_MARGIN = 12;
+/**
+ * Reward margin by which a switch must beat "stay" before the search
+ * overrides a heuristic "stay in" verdict. Higher than the veto margin
+ * — overriding the gate's anti-ping-pong protections needs strong
+ * evidence.
+ */
+const SWITCH_OVERRIDE_MARGIN = 18;
+
+/** Side ids as used by the tracker. */
+type TrackedSideID = "p1" | "p2" | "p3" | "p4";
+
+/** The slice of decision context a fork rollout needs. */
+interface ForkView {
+	mySide: TrackedSideID;
+	foeSide: TrackedSideID;
+	/** The foe active's revealed move ids (kept during determinization). */
+	revealedMoves: Set<string>;
+}
+
+/** Inferred foe reply/determinization pools shared across rollouts. */
+interface FoeModel {
+	foeIds: string[];
+	foeWeights: number[];
+	determinizeIds: string[];
+	determinizeWeights: number[];
+}
 
 interface CandidateNode {
 	id: string;
@@ -79,23 +156,29 @@ export class MctsEngine extends OnePlySearchEngine {
 			prior: priors[i],
 		}));
 
-		const inference = inferFoeActive(evalCtx.tracker);
-		const foeIds = inference ? topMoves(inference, FOE_SAMPLE_N) : [];
-		const foeWeights: number[] = (() => {
-			if (!inference) return [];
-			const raw = foeIds.map(id => inference.moves.get(id) ?? 0);
-			const sum = raw.reduce((a, b) => a + b, 0);
-			return sum > 0 ? raw.map(v => v / sum) : raw;
-		})();
+		const model = buildFoeModel(evalCtx.tracker);
+		const { foeIds, foeWeights } = model;
 
 		const budgetMs = ctx.searchBudgetMs ?? DEFAULT_BUDGET_MS;
 		const deadline = Date.now() + budgetMs;
 		let totalVisits = 0;
 
+		// True multi-turn search: when the host hands us the live battle
+		// (singles only — doubles slot pairing isn't modelled here), we
+		// snapshot it once and replay candidate turns on forks.
+		const snapshot = takeBattleSnapshot(ctx);
+		const view: ForkView = {
+			mySide: evalCtx.mySide,
+			foeSide: evalCtx.foeSide,
+			revealedMoves: evalCtx.defender.revealedMoves,
+		};
+
 		while (Date.now() < deadline) {
 			const pick = selectByPUCT(nodes, totalVisits);
 			if (!pick) break;
-			const reward = sampleRollout(pick, evalCtx, foeIds, foeWeights, ctx);
+			const reward = (snapshot ?
+				forkRollout(snapshot, `move ${pick.idx}`, view, model, ctx) :
+				null) ?? sampleRollout(pick, evalCtx, foeIds, foeWeights, ctx);
 			pick.visits += 1;
 			pick.totalReward += reward;
 			totalVisits += 1;
@@ -103,13 +186,18 @@ export class MctsEngine extends OnePlySearchEngine {
 			if (totalVisits >= 200 * nodes.length) break;
 		}
 
-		// Phase 2: emit final scores. A node with zero visits gets its
-		// heuristic baseline so we don't lose information when the
-		// budget was tiny.
+		// Phase 2: emit final scores. The rollout estimate is *blended*
+		// with the heuristic baseline rather than replacing it: rollout
+		// weight grows with visit count (more samples = less variance)
+		// up to ROLLOUT_MAX_WEIGHT, so a handful of noisy rollouts can
+		// break ties but can't overturn a confident heuristic read. A
+		// node with zero visits keeps its pure heuristic score.
 		return nodes.map((n, i) => {
-			const visited = n.visits > 0;
-			const meanReward = visited ? n.totalReward / n.visits : heuristicScores[i].heuristic;
-			let score = meanReward;
+			const heuristic = heuristicScores[i].heuristic;
+			const meanReward = n.visits > 0 ? n.totalReward / n.visits : heuristic;
+			const rolloutWeight = ROLLOUT_MAX_WEIGHT *
+				n.visits / (n.visits + ROLLOUT_HALF_WEIGHT_VISITS);
+			let score = (1 - rolloutWeight) * heuristic + rolloutWeight * meanReward;
 			if (ctx.infoForgetting > 0 && evalCtx.defender.revealedMoves.size > 0 &&
 				ctx.prng.random() < ctx.infoForgetting) {
 				score *= 0.85;
@@ -117,6 +205,132 @@ export class MctsEngine extends OnePlySearchEngine {
 			return { opt: { id: n.id, idx: n.idx }, score };
 		});
 	}
+
+	/**
+	 * Search-verified switch gate. The heuristic gate decides first;
+	 * when the live battle can be forked, the verdict is then checked
+	 * against multi-turn rollouts:
+	 *
+	 * - heuristic says **switch** → veto it when staying in clearly
+	 *   scores better (the gate's matchup math misses e.g. "we KO
+	 *   first" lines the simulator resolves correctly);
+	 * - heuristic says **stay** in a negative matchup → override to
+	 *   the best bench switch when rollouts strongly favour it (the
+	 *   gate's margin/veto stack misses e.g. "every move we have is
+	 *   resisted" situations).
+	 *
+	 * Both directions respect the switch lock and use asymmetric
+	 * margins so noisy rollouts can't induce ping-ponging.
+	 *
+	 * @param myMon Tracked active mon for this slot.
+	 * @param foeMon Tracked foe active.
+	 * @param tracker Battle state tracker.
+	 * @param side Our side's request payload.
+	 * @param slotIndex Slot being decided.
+	 * @param ctx Engine context.
+	 * @param switchCandidates Live bench candidates with request slots.
+	 * @param active Request payload for the active slot.
+	 * @returns A `switch N` command, or `null` to indicate "stay in".
+	 */
+	protected override maybeSwitchOut(
+		myMon: TrackedPokemon,
+		foeMon: TrackedPokemon,
+		tracker: BattleStateTracker,
+		side: SideRequestData,
+		slotIndex: number,
+		ctx: EngineContext,
+		switchCandidates: { req: PokemonSwitchRequestData, idx: number, mon: TrackedPokemon }[],
+		active: PokemonMoveRequestData
+	): string | null {
+		const heuristicChoice = super.maybeSwitchOut(
+			myMon, foeMon, tracker, side, slotIndex, ctx, switchCandidates, active
+		);
+		const snapshot = takeBattleSnapshot(ctx);
+		if (!snapshot) return heuristicChoice;
+
+		let switchChoice = heuristicChoice;
+		if (!switchChoice) {
+			// Candidate for a stay→switch override: only out of a losing
+			// matchup, never through the switch lock, and never into a
+			// bench mon that dies on entry.
+			const monId = this.monIdForSlot(side, slotIndex, ctx);
+			const lastSwitch = monId ? ctx.lastSwitchTurnByMon.get(monId) : undefined;
+			if (lastSwitch !== undefined && tracker.turn - lastSwitch < SWITCH_LOCK_TURNS) return null;
+			if (evaluateMatchup(myMon, foeMon, tracker).score >= 0) return null;
+			const best = chooseBestSwitch(switchCandidates.map(c => c.mon), foeMon, tracker);
+			if (!best || best.score.foeDealFraction + best.score.hazardFraction >= 0.95) return null;
+			const slot = switchCandidates.find(c => c.mon.id === best.mon.id);
+			if (!slot) return null;
+			switchChoice = `switch ${slot.idx}`;
+		}
+
+		const model = buildFoeModel(tracker);
+		const view: ForkView = {
+			mySide: tracker.mySide,
+			foeSide: tracker.foeSide,
+			revealedMoves: foeMon.revealedMoves,
+		};
+		const budgetMs = (ctx.searchBudgetMs ?? DEFAULT_BUDGET_MS) * SWITCH_EVAL_BUDGET_FRACTION;
+		const deadline = Date.now() + budgetMs;
+		const stay = meanForkReward(snapshot, "greedy", view, model, ctx, deadline);
+		const swap = meanForkReward(snapshot, switchChoice, view, model, ctx, deadline);
+		if (stay === null || swap === null) return heuristicChoice;
+
+		if (heuristicChoice) return stay - swap > SWITCH_VETO_MARGIN ? null : heuristicChoice;
+		return swap - stay > SWITCH_OVERRIDE_MARGIN ? switchChoice : null;
+	}
+}
+
+/**
+ * Build the inferred foe move pools shared by all rollouts of one
+ * decision: a narrow reply pool (what the foe likely clicks now) and a
+ * wider determinization pool (what its hidden slots may contain).
+ *
+ * @param tracker Battle state tracker.
+ * @returns The pools; all arrays are empty when inference has nothing.
+ */
+function buildFoeModel(tracker: BattleStateTracker): FoeModel {
+	const inference = inferFoeActive(tracker);
+	const foeIds = inference ? topMoves(inference, FOE_SAMPLE_N) : [];
+	const determinizeIds = inference ? topMoves(inference, DETERMINIZE_POOL_N) : [];
+	return {
+		foeIds,
+		foeWeights: inference ? normalizedWeights(foeIds, inference.moves) : [],
+		determinizeIds,
+		determinizeWeights: inference ? normalizedWeights(determinizeIds, inference.moves) : [],
+	};
+}
+
+/**
+ * Average fork-rollout reward for one root choice, bounded by both a
+ * rollout cap and a wall-clock deadline.
+ *
+ * @param snapshot JSON-string snapshot of the live battle.
+ * @param myChoice Root choice (`"greedy"` for the in-fork greedy move).
+ * @param view Side/revealed-move context for the rollouts.
+ * @param model Inferred foe move pools.
+ * @param ctx Engine context (PRNG).
+ * @param deadline Wall-clock cutoff (`Date.now()` ms).
+ * @returns The mean reward, or `null` when no rollout succeeded.
+ */
+function meanForkReward(
+	snapshot: string,
+	myChoice: string,
+	view: ForkView,
+	model: FoeModel,
+	ctx: EngineContext,
+	deadline: number
+): number | null {
+	let total = 0;
+	let count = 0;
+	for (let i = 0; i < SWITCH_EVAL_ROLLOUTS; i++) {
+		if (count > 0 && Date.now() >= deadline) break;
+		const reward = forkRollout(snapshot, myChoice, view, model, ctx);
+		if (reward === null) break;
+		total += reward;
+		count++;
+	}
+	return count > 0 ? total / count : null;
 }
 
 /** Standard PUCT: argmax q + c * prior * sqrt(N) / (1 + n). */
@@ -202,12 +416,381 @@ function sampleRollout(
 	return reward;
 }
 
+/**
+ * Serialize the live battle for fork rollouts, when available and the
+ * battle shape is one we can replay (2-side singles, mid move-request).
+ *
+ * The snapshot is a JSON *string*, not the `toJSON()` object:
+ * `State.deserializeBattle` reuses nested objects from its input, so
+ * deserializing the same object repeatedly would make every fork (and
+ * the live battle) share mutable state — fork turns would push into the
+ * live battle's log until the sim's "Infinite loop" guard fired.
+ * Round-tripping through `JSON.parse` gives each fork a private copy.
+ * (Measured: parse+deserialize is ~0.3ms per fork — cheaper than
+ * `structuredClone` on this data and negligible next to the rollout
+ * simulation itself.)
+ *
+ * @param ctx Engine context (provides the optional `getBattle` hook).
+ * @returns The serialized battle, or `null` when forking is
+ *   unavailable or unsupported for this battle.
+ */
+function takeBattleSnapshot(ctx: EngineContext): string | null {
+	const live = ctx.getBattle?.();
+	if (!live || live.ended) return null;
+	if (live.sides.length !== 2 || live.gameType !== "singles") return null;
+	if (live.requestState !== "move") return null;
+	try {
+		return JSON.stringify(live.toJSON());
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Play one full multi-turn rollout on a fork of the real battle:
+ *
+ * 1. `Battle.fromJSON(snapshot)` clones the live state, re-seeded from
+ *    the engine PRNG so each rollout samples fresh damage rolls.
+ * 2. The fork is *determinized*: the foe active's unrevealed move slots
+ *    are overwritten with a fresh weighted sample from the
+ *    {@link OpponentInference} prior pool, so the search plays against
+ *    what we *believe* the foe has rather than reading its true hidden
+ *    set (no full-info cheating). Sampling a different plausible set
+ *    per rollout means repeated visits average over determinizations
+ *    instead of anchoring on a single guess.
+ * 3. The root action is committed against a sampled foe reply, then
+ *    {@link FORK_ROLLOUT_TURNS} more turns are played with a cheap
+ *    greedy policy (forced switches auto-resolve).
+ * 4. The reward is the HP/faint differential swing across the rollout,
+ *    plus a win/loss bonus if the battle ended.
+ *
+ * @param snapshot JSON-string snapshot of the live battle.
+ * @param myChoice Our root action (`"move N"` / `"switch N"`), or
+ *   `"greedy"` to let the in-fork greedy policy pick it.
+ * @param view Side ids and the foe's revealed-move set.
+ * @param model Inferred foe reply/determinization pools.
+ * @param ctx Engine context (PRNG).
+ * @returns The rollout reward, or `null` when the fork could not be
+ *   built or the root choice was rejected (caller falls back to the
+ *   tracker-only sampler).
+ */
+function forkRollout(
+	snapshot: string,
+	myChoice: string,
+	view: ForkView,
+	model: FoeModel,
+	ctx: EngineContext
+): number | null {
+	let fork: Battle;
+	try {
+		fork = Battle.fromJSON(snapshot);
+	} catch {
+		return null;
+	}
+	fork.prng = PRNG.get(forkSeed(ctx));
+	const mySide = fork.sides.find(s => s.id === view.mySide);
+	const foeSide = fork.sides.find(s => s.id === view.foeSide);
+	if (!mySide || !foeSide) return null;
+
+	const foeActive = foeSide.active[0];
+	if (foeActive) {
+		determinizeMoves(foeActive, view.revealedMoves, model.determinizeIds, model.determinizeWeights, ctx);
+	}
+
+	const before = evaluateForkState(fork, mySide);
+	try {
+		// Foe reply first (order doesn't matter; commit fires once both
+		// sides are done).
+		const foeChoice = pickForkFoeChoice(fork, foeSide, foeActive, model.foeIds, model.foeWeights, ctx);
+		if (!fork.choose(foeSide.id, foeChoice)) {
+			if (!fork.choose(foeSide.id, "default")) return null;
+		}
+		const rootChoice = myChoice === "greedy" ? greedyChoiceForSide(fork, mySide) : myChoice;
+		if (!fork.choose(mySide.id, rootChoice)) return null;
+		resolvePendingChoices(fork);
+		for (let t = 0; t < FORK_ROLLOUT_TURNS && !fork.ended; t++) {
+			if (fork.requestState === "move") {
+				playGreedyTurn(fork);
+			} else {
+				fork.makeChoices();
+			}
+			resolvePendingChoices(fork);
+		}
+	} catch {
+		// Forks can die on exotic mechanics (forme bugs, choice-lock edge
+		// cases); score whatever state we reached rather than discarding
+		// the visit entirely.
+	}
+
+	const after = evaluateForkState(fork, mySide);
+	let reward = (after - before) * FORK_REWARD_SCALE;
+	if (fork.ended) {
+		if (fork.winner === mySide.name) reward += FORK_WIN_BONUS;
+		else if (fork.winner) reward -= FORK_WIN_BONUS;
+	}
+	return reward;
+}
+
+/**
+ * Derive a fresh battle seed from the engine PRNG so consecutive
+ * rollouts diverge while the engine itself stays reproducible.
+ *
+ * @param ctx Engine context providing the PRNG.
+ * @returns A four-part numeric PRNG seed.
+ */
+function forkSeed(ctx: EngineContext): PRNGSeed {
+	return [
+		ctx.prng.random(2 ** 16), ctx.prng.random(2 ** 16),
+		ctx.prng.random(2 ** 16), ctx.prng.random(2 ** 16),
+	].join(",") as PRNGSeed;
+}
+
+/**
+ * Overwrite the foe active's *unrevealed* move slots with a weighted
+ * sample (without replacement) from the inferred-move pool. Revealed
+ * moves are kept untouched; fills skip moves the mon already has.
+ * Because the sample is re-drawn per rollout, repeated visits to the
+ * same candidate average over many plausible foe sets.
+ *
+ * @param foeActive The foe's active Pokemon in the fork.
+ * @param revealed The foe active's revealed move ids (kept untouched).
+ * @param pool Inferred move-id pool to sample fills from.
+ * @param weights Sampling weights parallel to `pool`.
+ * @param ctx Engine context (PRNG).
+ */
+function determinizeMoves(
+	foeActive: Pokemon,
+	revealed: Set<string>,
+	pool: string[],
+	weights: number[],
+	ctx: EngineContext
+): void {
+	if (!pool.length) return;
+	const present = new Set<string>(foeActive.moveSlots.map(s => s.id));
+	const eligible: string[] = [];
+	const eligibleWeights: number[] = [];
+	for (const [i, id] of pool.entries()) {
+		if (present.has(id)) continue;
+		eligible.push(id);
+		eligibleWeights.push(weights[i] ?? 0);
+	}
+	const fills = sampleWithoutReplacement(eligible, eligibleWeights, ctx);
+	for (const slot of foeActive.moveSlots) {
+		if (revealed.has(slot.id)) continue;
+		const next = fills.shift();
+		if (!next) break;
+		const mv = Dex.moves.get(next);
+		if (!mv?.exists) continue;
+		slot.move = mv.name;
+		slot.id = mv.id;
+		slot.pp = mv.pp;
+		slot.maxpp = mv.pp;
+		slot.target = mv.target;
+		slot.disabled = false;
+	}
+}
+
+/**
+ * Pick the foe's reply for the root turn of a fork rollout: usually
+ * its greedy max-damage move on the determinized set (real opponents
+ * play near-greedy), otherwise a prior-weighted sample for variety.
+ * Falls back to the simulator default when neither produces a usable
+ * move.
+ *
+ * @param fork The forked battle.
+ * @param foeSide The foe's side in the fork.
+ * @param foeActive The foe's active Pokemon in the fork.
+ * @param foeIds Inferred move ids.
+ * @param foeWeights Sampling weights parallel to `foeIds`.
+ * @param ctx Engine context (PRNG).
+ * @returns A choice string for `Battle.choose`.
+ */
+function pickForkFoeChoice(
+	fork: Battle,
+	foeSide: Side,
+	foeActive: Pokemon | null,
+	foeIds: string[],
+	foeWeights: number[],
+	ctx: EngineContext
+): string {
+	if (!foeActive) return "default";
+	if (ctx.prng.random() < GREEDY_FOE_REPLY_CHANCE) {
+		return greedyChoiceForSide(fork, foeSide);
+	}
+	const sampled = sampleWeighted(foeIds, foeWeights, ctx);
+	if (!sampled) return "default";
+	const idx = foeActive.moveSlots.findIndex(
+		s => s.id === sampled && !s.disabled && s.pp > 0
+	);
+	return idx >= 0 ? `move ${idx + 1}` : "default";
+}
+
+/**
+ * Resolve any pending mid-turn requests (forced switches after faints,
+ * U-turn targets, etc.) with the simulator's auto-choose so the fork
+ * reaches the next stable turn boundary.
+ *
+ * @param fork The forked battle.
+ */
+function resolvePendingChoices(fork: Battle): void {
+	let guard = 0;
+	while (!fork.ended && fork.requestState === "switch" && guard++ < 6) {
+		fork.makeChoices();
+	}
+}
+
+/**
+ * Play one fork turn with a cheap greedy policy for both sides: the
+ * usable move with the highest effective base power (STAB and type
+ * effectiveness against the opposing active included).
+ *
+ * @param fork The forked battle, mid move-request.
+ */
+function playGreedyTurn(fork: Battle): void {
+	const turnBefore = fork.turn;
+	for (const side of fork.sides) {
+		if (side.isChoiceDone()) continue;
+		const choice = greedyChoiceForSide(fork, side);
+		if (!fork.choose(side.id, choice)) fork.choose(side.id, "default");
+		// The last successful choice commits the turn.
+		if (fork.ended || fork.turn !== turnBefore) return;
+	}
+	// A rejected choice left the turn uncommitted — let the simulator
+	// auto-resolve rather than stalling the rollout.
+	if (!fork.ended && fork.turn === turnBefore) fork.makeChoices();
+}
+
+/**
+ * Greedy move pick for a fork side: max `BP x STAB x effectiveness`
+ * across usable move slots.
+ *
+ * @param fork The forked battle.
+ * @param side The side to choose for.
+ * @returns A choice string for `Battle.choose`.
+ */
+function greedyChoiceForSide(fork: Battle, side: Side): string {
+	const active = side.active[0];
+	if (!active || active.fainted) return "default";
+	const foe = side.foe?.active[0] ?? null;
+	let bestIdx = -1;
+	let bestScore = -Infinity;
+	for (const [i, slot] of active.moveSlots.entries()) {
+		if (slot.disabled || slot.pp <= 0) continue;
+		const mv = Dex.moves.get(slot.id);
+		if (!mv?.exists) continue;
+		const bp = typeof mv.basePower === "number" ? mv.basePower : 0;
+		const stab = active.types.includes(mv.type) ? 1.5 : 1;
+		const eff = foe && bp > 0 ?
+			(Dex.getImmunity(mv.type, foe.types) ? 2 ** foe.types.reduce(
+				(acc, t) => acc + Dex.getEffectiveness(mv.type, t), 0
+			) : 0) :
+			1;
+		const score = bp * stab * eff;
+		if (score > bestScore) {
+			bestScore = score;
+			bestIdx = i;
+		}
+	}
+	return bestIdx >= 0 ? `move ${bestIdx + 1}` : "default";
+}
+
+/**
+ * Static evaluation of a fork in "mons" units (each living mon
+ * contributes up to ~1.3 from HP fraction + alive bonus), refined by
+ * positional terms a pure material count misses:
+ *
+ * - non-volatile status on living mons (burn/para/tox cost real value),
+ * - net stat-boost stages on the actives (a free setup turn is worth
+ *   something even before it converts to damage),
+ * - entry hazards stacked on each side (they tax future switches).
+ *
+ * @param fork The forked battle.
+ * @param mySide Our side in the fork.
+ * @returns Positive when we're ahead.
+ */
+function evaluateForkState(fork: Battle, mySide: Side): number {
+	let score = 0;
+	for (const side of fork.sides) {
+		const sign = side === mySide ? 1 : -1;
+		for (const p of side.pokemon) {
+			const hpFraction = p.maxhp > 0 ? p.hp / p.maxhp : 0;
+			let value = hpFraction + (p.hp > 0 ? 0.3 : 0);
+			if (p.hp > 0 && p.status) value -= STATUS_EVAL_PENALTY;
+			score += sign * value;
+		}
+		const active = side.active[0];
+		if (active && !active.fainted) {
+			let netBoosts = 0;
+			for (const stage of Object.values(active.boosts)) netBoosts += stage;
+			score += sign * BOOST_EVAL_VALUE * netBoosts;
+		}
+		score -= sign * hazardPressure(side);
+	}
+	return score;
+}
+
+/**
+ * Cost of the entry hazards currently stacked on a side, in the same
+ * "mons" units as {@link evaluateForkState}.
+ *
+ * @param side The side whose hazards are being scored.
+ * @returns The total hazard tax (0 when the side is clean).
+ */
+function hazardPressure(side: Side): number {
+	let cost = 0;
+	if (side.sideConditions["stealthrock"]) cost += 0.15;
+	const spikes = side.sideConditions["spikes"];
+	if (spikes) cost += 0.07 * (spikes.layers ?? 1);
+	const tspikes = side.sideConditions["toxicspikes"];
+	if (tspikes) cost += 0.06 * (tspikes.layers ?? 1);
+	if (side.sideConditions["stickyweb"]) cost += 0.08;
+	return cost;
+}
+
 function softmax(values: number[]): number[] {
 	if (!values.length) return [];
 	const max = Math.max(...values);
 	const exps = values.map(v => Math.exp((v - max) / 25));
 	const sum = exps.reduce((a, b) => a + b, 0);
 	return sum > 0 ? exps.map(e => e / sum) : values.map(() => 1 / values.length);
+}
+
+/**
+ * Normalize inference scores for a set of move ids into sampling
+ * weights that sum to 1.
+ *
+ * @param ids Move ids to weight.
+ * @param scores Raw inference scores keyed by move id.
+ * @returns Weights parallel to `ids` (all zero when scores sum to 0).
+ */
+function normalizedWeights(ids: string[], scores: Map<string, number>): number[] {
+	const raw = ids.map(id => scores.get(id) ?? 0);
+	const sum = raw.reduce((a, b) => a + b, 0);
+	return sum > 0 ? raw.map(v => v / sum) : raw;
+}
+
+/**
+ * Weighted sample without replacement: draws ids one at a time
+ * proportionally to their weight until the pool is exhausted.
+ *
+ * @param ids Candidate ids.
+ * @param weights Sampling weights parallel to `ids`.
+ * @param ctx Engine context (PRNG).
+ * @returns The ids in sampled order.
+ */
+function sampleWithoutReplacement(ids: string[], weights: number[], ctx: EngineContext): string[] {
+	const remainingIds = ids.slice();
+	const remainingWeights = weights.slice();
+	const out: string[] = [];
+	while (remainingIds.length) {
+		const sampled = sampleWeighted(remainingIds, remainingWeights, ctx);
+		if (!sampled) break;
+		const i = remainingIds.indexOf(sampled);
+		remainingIds.splice(i, 1);
+		remainingWeights.splice(i, 1);
+		out.push(sampled);
+	}
+	return out;
 }
 
 function sampleWeighted(ids: string[], weights: number[], ctx: EngineContext): string | null {

--- a/sim/tools/strategic-ai/engines/MctsEngine.ts
+++ b/sim/tools/strategic-ai/engines/MctsEngine.ts
@@ -566,7 +566,11 @@ function determinizeMoves(
 	ctx: EngineContext
 ): void {
 	if (!pool.length) return;
-	const present = new Set<string>(foeActive.moveSlots.map(s => s.id));
+	// Exclude only *revealed* moves from the fill pool. Seeding this from the
+	// foe's real move slots would leak hidden information: it would bias the
+	// sampled fills away from the moves the foe actually has, so a fill could
+	// never coincide with the (unrevealed) truth.
+	const present = new Set<string>(revealed);
 	const eligible: string[] = [];
 	const eligibleWeights: number[] = [];
 	for (const [i, id] of pool.entries()) {

--- a/sim/tools/strategic-ai/mechanics/DamageCalc.ts
+++ b/sim/tools/strategic-ai/mechanics/DamageCalc.ts
@@ -489,11 +489,11 @@ function resolveMoveType(move: Move, input: DamageCalcInput): string {
 	}
 	if (type === "Normal") {
 		switch (ability) {
-			case "aerilate": return "Flying";
-			case "pixilate": return "Fairy";
-			case "refrigerate": return "Ice";
-			case "galvanize": return "Electric";
-			case "normalize": return "Normal"; // No-op on Normal; -ate boost still applies.
+		case "aerilate": return "Flying";
+		case "pixilate": return "Fairy";
+		case "refrigerate": return "Ice";
+		case "galvanize": return "Electric";
+		case "normalize": return "Normal"; // No-op on Normal; -ate boost still applies.
 		}
 	}
 	return type;
@@ -503,22 +503,22 @@ function abilityImmunityBlocks(moveType: string, move: Move, input: DamageCalcIn
 	const ability = toID(input.defender.ability);
 	if (move.category === "Status") return false;
 	switch (ability) {
-		case "voltabsorb":
-		case "lightningrod":
-		case "motordrive":
-			return moveType === "Electric";
-		case "waterabsorb":
-		case "stormdrain":
-		case "dryskin":
-			return moveType === "Water";
-		case "flashfire":
-			return moveType === "Fire";
-		case "sapsipper":
-			return moveType === "Grass";
-		case "levitate":
-			return moveType === "Ground" && !input.field.gravity;
-		case "wonderguard":
-			return typeEffectivenessExp(moveType, input.defender) <= 0;
+	case "voltabsorb":
+	case "lightningrod":
+	case "motordrive":
+		return moveType === "Electric";
+	case "waterabsorb":
+	case "stormdrain":
+	case "dryskin":
+		return moveType === "Water";
+	case "flashfire":
+		return moveType === "Fire";
+	case "sapsipper":
+		return moveType === "Grass";
+	case "levitate":
+		return moveType === "Ground" && !input.field.gravity;
+	case "wonderguard":
+		return typeEffectivenessExp(moveType, input.defender) <= 0;
 	}
 	return false;
 }
@@ -542,96 +542,113 @@ function computeBasePower(move: Move, moveType: string, input: DamageCalcInput):
 
 	// Some ID-specific BP recomputations.
 	switch (id) {
-		case "earthquake":
-		case "magnitude":
-			break;
-		case "knockoff":
-			if (input.defender.item) bp *= 1.5;
-			break;
-		case "facade":
-			if (input.attacker.status && input.attacker.status !== "frz" && input.attacker.status !== "slp") {
-				bp *= 2;
-			}
-			break;
-		case "hex":
-			if (input.defender.status) bp *= 2;
-			break;
-		case "venoshock":
-			if (input.defender.status === "psn" || input.defender.status === "tox") bp *= 2;
-			break;
-		case "acrobatics":
-			if (!input.attacker.item) bp *= 2;
-			break;
-		case "lowkick":
-		case "grassknot":
-			// Weight-based; we approximate with average BP of 80.
-			bp = Math.max(bp, 80);
-			break;
-		case "heavyslam":
-		case "heatcrash":
-			bp = Math.max(bp, 80);
-			break;
-		case "gyroball":
-			bp = Math.max(bp, 60);
-			break;
-		case "electroball":
-			bp = Math.max(bp, 80);
-			break;
-		case "weatherball":
-			if (input.field.weather && input.field.weather !== "none") bp = 100;
-			break;
-		case "terrainpulse":
-			if (input.field.terrain) bp = 100;
-			break;
-		case "boltbeak":
-		case "fishiousrend":
-			// 2× if the attacker moves first this turn — we now have
-			// the hint from the caller. When the hint is missing
-			// (`undefined`), fall back to the historical 1.5× midpoint
-			// estimate rather than guess wrong either way.
-			if (input.attackerMovesFirst === true) bp *= 2;
-			else if (input.attackerMovesFirst === undefined) bp *= 1.5;
-			break;
-		case "payback":
-			// 2× if the attacker moves second.
-			if (input.attackerMovesFirst === false) bp *= 2;
-			break;
-		case "revenge":
-		case "avalanche":
-			// 2× if the attacker took damage from the foe this turn.
-			// We approximate that as "foe moves first" — the typical
-			// scenario where Revenge / Avalanche actually fire. (False
-			// positives in the unusual "foe used a status move first
-			// turn" case are tolerable; the scoring layer cross-checks
-			// `defender.lastMove?.category` for the higher-value
-			// branches.)
-			if (input.attackerMovesFirst === false) bp *= 2;
-			break;
-		case "assurance":
-			// 2× if the target has already taken damage this turn —
-			// classic doubles partner combo, or any prior hit on the
-			// same target in singles (multi-hit interruption, etc.).
-			if (input.defenderTookDamageThisTurn) bp *= 2;
-			break;
-		case "lashout":
-			// 2× if the attacker's stat stages were lowered this turn
-			// (Intimidate switch-in, Sticky Web, foe Sword Dance/Snarl).
-			if (input.attackerLostStatThisTurn) bp *= 2;
-			break;
-		case "stompingtantrum":
-			// 2× if the user's *previous* move failed. The engine sets
-			// this flag from `lastMoveFailedByMon` (LogParser feeds it
-			// from `|miss|` / `|-immune|` / `|cant|` events). The
-			// classic "Earthquake into Levitate → Stomping Tantrum"
-			// combo finally scores correctly.
-			if (input.attackerLastMoveFailed) bp *= 2;
-			break;
-		case "lastrespects":
-			// Scales with team faints; approximate with +1 per faint.
-			break;
-		case "rage Fist":
-		case "ragefist":
-			break;
+	case "earthquake":
+	case "magnitude":
+		break;
+	case "knockoff":
+		if (input.defender.item) bp *= 1.5;
+		break;
+	case "facade":
+		if (input.attacker.status && input.attacker.status !== "frz" && input.attacker.status !== "slp") {
+			bp *= 2;
+		}
+		break;
+	case "hex":
+		if (input.defender.status) bp *= 2;
+		break;
+	case "venoshock":
+		if (input.defender.status === "psn" || input.defender.status === "tox") bp *= 2;
+		break;
+	case "acrobatics":
+		if (!input.attacker.item) bp *= 2;
+		break;
+	case "lowkick":
+	case "grassknot": {
+		// Defender-weight ladder (hectograms): >=200kg → 120 BP
+		// down to <10kg → 20 BP.
+		const w = speciesWeightHg(input.defender);
+		bp = w >= 2000 ? 120 : w >= 1000 ? 100 : w >= 500 ? 80 : w >= 250 ? 60 : w >= 100 ? 40 : 20;
+		break;
+	}
+	case "heavyslam":
+	case "heatcrash": {
+		// Attacker/defender weight ratio ladder: >=5× → 120 BP
+		// down to <2× → 40 BP.
+		const ratio = speciesWeightHg(input.attacker) / Math.max(1, speciesWeightHg(input.defender));
+		bp = ratio >= 5 ? 120 : ratio >= 4 ? 100 : ratio >= 3 ? 80 : ratio >= 2 ? 60 : 40;
+		break;
+	}
+	case "gyroball": {
+		// BP = 25 × (target speed / user speed) + 1, capped at 150.
+		const userSpe = Math.max(1, effectiveStat(input.attacker, "spe"));
+		const targetSpe = effectiveStat(input.defender, "spe");
+		bp = Math.min(150, Math.floor((25 * targetSpe) / userSpe) + 1);
+		break;
+	}
+	case "electroball": {
+		// User/target speed ratio ladder: >=4× → 150 BP down to 40.
+		const userSpe = effectiveStat(input.attacker, "spe");
+		const targetSpe = Math.max(1, effectiveStat(input.defender, "spe"));
+		const ratio = userSpe / targetSpe;
+		bp = ratio >= 4 ? 150 : ratio >= 3 ? 120 : ratio >= 2 ? 80 : ratio >= 1 ? 60 : 40;
+		break;
+	}
+	case "weatherball":
+		if (input.field.weather && input.field.weather !== "none") bp = 100;
+		break;
+	case "terrainpulse":
+		if (input.field.terrain) bp = 100;
+		break;
+	case "boltbeak":
+	case "fishiousrend":
+		// 2× if the attacker moves first this turn — we now have
+		// the hint from the caller. When the hint is missing
+		// (`undefined`), fall back to the historical 1.5× midpoint
+		// estimate rather than guess wrong either way.
+		if (input.attackerMovesFirst === true) bp *= 2;
+		else if (input.attackerMovesFirst === undefined) bp *= 1.5;
+		break;
+	case "payback":
+		// 2× if the attacker moves second.
+		if (input.attackerMovesFirst === false) bp *= 2;
+		break;
+	case "revenge":
+	case "avalanche":
+		// 2× if the attacker took damage from the foe this turn.
+		// We approximate that as "foe moves first" — the typical
+		// scenario where Revenge / Avalanche actually fire. (False
+		// positives in the unusual "foe used a status move first
+		// turn" case are tolerable; the scoring layer cross-checks
+		// `defender.lastMove?.category` for the higher-value
+		// branches.)
+		if (input.attackerMovesFirst === false) bp *= 2;
+		break;
+	case "assurance":
+		// 2× if the target has already taken damage this turn —
+		// classic doubles partner combo, or any prior hit on the
+		// same target in singles (multi-hit interruption, etc.).
+		if (input.defenderTookDamageThisTurn) bp *= 2;
+		break;
+	case "lashout":
+		// 2× if the attacker's stat stages were lowered this turn
+		// (Intimidate switch-in, Sticky Web, foe Sword Dance/Snarl).
+		if (input.attackerLostStatThisTurn) bp *= 2;
+		break;
+	case "stompingtantrum":
+		// 2× if the user's *previous* move failed. The engine sets
+		// this flag from `lastMoveFailedByMon` (LogParser feeds it
+		// from `|miss|` / `|-immune|` / `|cant|` events). The
+		// classic "Earthquake into Levitate → Stomping Tantrum"
+		// combo finally scores correctly.
+		if (input.attackerLastMoveFailed) bp *= 2;
+		break;
+	case "lastrespects":
+		// 50 + 50 per fainted party member on the user's side.
+		bp = 50 + 50 * input.attackerSide.fainted;
+		break;
+	case "rage Fist":
+	case "ragefist":
+		break;
 	}
 
 	// Terrain BP boosts (only when grounded, simplified).
@@ -649,38 +666,38 @@ function computeBasePower(move: Move, moveType: string, input: DamageCalcInput):
 
 	// Ability BP boosts.
 	switch (ability) {
-		case "technician": if (bp <= 60) bp *= 1.5; break;
-		case "ironfist": if (move.flags?.punch) bp *= 1.2; break;
-		case "strongjaw": if (move.flags?.bite) bp *= 1.5; break;
-		case "megalauncher": if (move.flags?.pulse) bp *= 1.5; break;
-		case "toughclaws": if (move.flags?.contact) bp *= 1.3; break;
-		case "rivalry": /* depends on gender; ignored */ break;
-		case "swarm": if (moveType === "Bug" && (input.attacker.hpFraction ?? 1) <= 1 / 3) bp *= 1.5; break;
-		case "blaze": if (moveType === "Fire" && (input.attacker.hpFraction ?? 1) <= 1 / 3) bp *= 1.5; break;
-		case "torrent": if (moveType === "Water" && (input.attacker.hpFraction ?? 1) <= 1 / 3) bp *= 1.5; break;
-		case "overgrow": if (moveType === "Grass" && (input.attacker.hpFraction ?? 1) <= 1 / 3) bp *= 1.5; break;
-		case "sandforce":
-			if (input.field.weather === "sandstorm" && (moveType === "Rock" || moveType === "Ground" || moveType === "Steel")) {
-				bp *= 1.3;
-			}
-			break;
-		case "punkrock": if (move.flags?.sound) bp *= 1.3; break;
-		case "aerilate":
-		case "pixilate":
-		case "refrigerate":
-		case "galvanize":
-			if (move.type === "Normal" && moveType !== "Normal") bp *= 1.2;
-			break;
-		case "normalize":
-			if (moveType === "Normal" && (move.type !== "Normal" || true)) bp *= 1.2;
-			break;
-		case "stakeout": /* needs "switched in this turn" tracking; skipped */ break;
-		case "sheerforce":
-			if (move.secondaries?.length || (move as { hasSheerForce?: boolean }).hasSheerForce) bp *= 1.3;
-			break;
-		case "analytic": /* needs move-order; skipped */ break;
-		case "darkaura": if (moveType === "Dark") bp *= 4 / 3; break;
-		case "fairyaura": if (moveType === "Fairy") bp *= 4 / 3; break;
+	case "technician": if (bp <= 60) bp *= 1.5; break;
+	case "ironfist": if (move.flags?.punch) bp *= 1.2; break;
+	case "strongjaw": if (move.flags?.bite) bp *= 1.5; break;
+	case "megalauncher": if (move.flags?.pulse) bp *= 1.5; break;
+	case "toughclaws": if (move.flags?.contact) bp *= 1.3; break;
+	case "rivalry": /* depends on gender; ignored */ break;
+	case "swarm": if (moveType === "Bug" && (input.attacker.hpFraction ?? 1) <= 1 / 3) bp *= 1.5; break;
+	case "blaze": if (moveType === "Fire" && (input.attacker.hpFraction ?? 1) <= 1 / 3) bp *= 1.5; break;
+	case "torrent": if (moveType === "Water" && (input.attacker.hpFraction ?? 1) <= 1 / 3) bp *= 1.5; break;
+	case "overgrow": if (moveType === "Grass" && (input.attacker.hpFraction ?? 1) <= 1 / 3) bp *= 1.5; break;
+	case "sandforce":
+		if (input.field.weather === "sandstorm" && (moveType === "Rock" || moveType === "Ground" || moveType === "Steel")) {
+			bp *= 1.3;
+		}
+		break;
+	case "punkrock": if (move.flags?.sound) bp *= 1.3; break;
+	case "aerilate":
+	case "pixilate":
+	case "refrigerate":
+	case "galvanize":
+		if (move.type === "Normal" && moveType !== "Normal") bp *= 1.2;
+		break;
+	case "normalize":
+		if (moveType === "Normal" && (move.type !== "Normal" || true)) bp *= 1.2;
+		break;
+	case "stakeout": /* needs "switched in this turn" tracking; skipped */ break;
+	case "sheerforce":
+		if (move.secondaries?.length || (move as { hasSheerForce?: boolean }).hasSheerForce) bp *= 1.3;
+		break;
+	case "analytic": /* needs move-order; skipped */ break;
+	case "darkaura": if (moveType === "Dark") bp *= 4 / 3; break;
+	case "fairyaura": if (moveType === "Fairy") bp *= 4 / 3; break;
 	}
 
 	// Item BP boosts. (Choice Band is an Atk multiplier, not BP, so it's
@@ -1009,29 +1026,29 @@ function computeHitChance(move: Move, input: DamageCalcInput): number {
 
 function typeBoostingItem(itemId: string, moveType: string): boolean {
 	switch (itemId) {
-		case "blackbelt": return moveType === "Fighting";
-		case "blackglasses": return moveType === "Dark";
-		case "charcoal": return moveType === "Fire";
-		case "dragonfang": return moveType === "Dragon";
-		case "hardstone": return moveType === "Rock";
-		case "magnet": return moveType === "Electric";
-		case "metalcoat": return moveType === "Steel";
-		case "miracleseed": return moveType === "Grass";
-		case "mysticwater": return moveType === "Water";
-		case "neverMeltIce":
-		case "nevermelltice":
-		case "nevermelitice":
-		case "nevermellice":
-		case "nevermeltice":
-			return moveType === "Ice";
-		case "poisonbarb": return moveType === "Poison";
-		case "sharpbeak": return moveType === "Flying";
-		case "silkscarf": return moveType === "Normal";
-		case "silverpowder": return moveType === "Bug";
-		case "softsand": return moveType === "Ground";
-		case "spelltag": return moveType === "Ghost";
-		case "twistedspoon": return moveType === "Psychic";
-		case "fairyfeather": return moveType === "Fairy";
+	case "blackbelt": return moveType === "Fighting";
+	case "blackglasses": return moveType === "Dark";
+	case "charcoal": return moveType === "Fire";
+	case "dragonfang": return moveType === "Dragon";
+	case "hardstone": return moveType === "Rock";
+	case "magnet": return moveType === "Electric";
+	case "metalcoat": return moveType === "Steel";
+	case "miracleseed": return moveType === "Grass";
+	case "mysticwater": return moveType === "Water";
+	case "neverMeltIce":
+	case "nevermelltice":
+	case "nevermelitice":
+	case "nevermellice":
+	case "nevermeltice":
+		return moveType === "Ice";
+	case "poisonbarb": return moveType === "Poison";
+	case "sharpbeak": return moveType === "Flying";
+	case "silkscarf": return moveType === "Normal";
+	case "silverpowder": return moveType === "Bug";
+	case "softsand": return moveType === "Ground";
+	case "spelltag": return moveType === "Ghost";
+	case "twistedspoon": return moveType === "Psychic";
+	case "fairyfeather": return moveType === "Fairy";
 	}
 	if (itemId.endsWith("plate")) {
 		const t = platedItemType(itemId);
@@ -1047,24 +1064,24 @@ function typeBoostingItem(itemId: string, moveType: string): boolean {
 function typeResistBerry(itemId: string, moveType: string, eff: number): boolean {
 	if (eff <= 0 && itemId !== "chilanberry") return false;
 	switch (itemId) {
-		case "occaberry": return moveType === "Fire";
-		case "passhoberry": return moveType === "Water";
-		case "wacanberry": return moveType === "Electric";
-		case "rindoberry": return moveType === "Grass";
-		case "yacheberry": return moveType === "Ice";
-		case "chopleberry": return moveType === "Fighting";
-		case "kebiaberry": return moveType === "Poison";
-		case "shucaberry": return moveType === "Ground";
-		case "cobaberry": return moveType === "Flying";
-		case "payapaberry": return moveType === "Psychic";
-		case "tangaberry": return moveType === "Bug";
-		case "chartiberry": return moveType === "Rock";
-		case "kasibberry": return moveType === "Ghost";
-		case "habanberry": return moveType === "Dragon";
-		case "colburberry": return moveType === "Dark";
-		case "babiriberry": return moveType === "Steel";
-		case "roseliberry": return moveType === "Fairy";
-		case "chilanberry": return moveType === "Normal";
+	case "occaberry": return moveType === "Fire";
+	case "passhoberry": return moveType === "Water";
+	case "wacanberry": return moveType === "Electric";
+	case "rindoberry": return moveType === "Grass";
+	case "yacheberry": return moveType === "Ice";
+	case "chopleberry": return moveType === "Fighting";
+	case "kebiaberry": return moveType === "Poison";
+	case "shucaberry": return moveType === "Ground";
+	case "cobaberry": return moveType === "Flying";
+	case "payapaberry": return moveType === "Psychic";
+	case "tangaberry": return moveType === "Bug";
+	case "chartiberry": return moveType === "Rock";
+	case "kasibberry": return moveType === "Ghost";
+	case "habanberry": return moveType === "Dragon";
+	case "colburberry": return moveType === "Dark";
+	case "babiriberry": return moveType === "Steel";
+	case "roseliberry": return moveType === "Fairy";
+	case "chilanberry": return moveType === "Normal";
 	}
 	return false;
 }
@@ -1107,6 +1124,20 @@ function memoryItemType(itemId: string): string | null {
 	const t = itemId.slice(0, -"memory".length);
 	const cap = t.charAt(0).toUpperCase() + t.slice(1);
 	return cap || null;
+}
+
+/**
+ * Species weight in hectograms, for weight-based BP moves (Low Kick,
+ * Grass Knot, Heavy Slam, Heat Crash). Falls back to 100 hg (10 kg)
+ * when the species is unknown.
+ *
+ * @param mon The Pokemon whose weight to look up.
+ * @returns Weight in hectograms.
+ */
+function speciesWeightHg(mon: CalcPokemon): number {
+	const species = Dex.species.get(mon.species);
+	if (!species?.exists) return 100;
+	return species.weighthg || 100;
 }
 
 function isNFE(speciesId: string): boolean {

--- a/sim/tools/strategic-ai/mechanics/DamageCalc.ts
+++ b/sim/tools/strategic-ai/mechanics/DamageCalc.ts
@@ -487,13 +487,15 @@ function resolveMoveType(move: Move, input: DamageCalcInput): string {
 		const memoryType = memoryItemType(toID(input.attacker.item));
 		if (memoryType) type = memoryType;
 	}
+	// Normalize converts every move to Normal (not just already-Normal ones),
+	// so it applies regardless of the move's original type.
+	if (ability === "normalize") return "Normal";
 	if (type === "Normal") {
 		switch (ability) {
 		case "aerilate": return "Flying";
 		case "pixilate": return "Fairy";
 		case "refrigerate": return "Ice";
 		case "galvanize": return "Electric";
-		case "normalize": return "Normal"; // No-op on Normal; -ate boost still applies.
 		}
 	}
 	return type;
@@ -689,7 +691,9 @@ function computeBasePower(move: Move, moveType: string, input: DamageCalcInput):
 		if (move.type === "Normal" && moveType !== "Normal") bp *= 1.2;
 		break;
 	case "normalize":
-		if (moveType === "Normal" && (move.type !== "Normal" || true)) bp *= 1.2;
+		// Only the moves Normalize actually converted (originally non-Normal)
+		// get the 1.2x boost, mirroring Showdown's typeChangerBoosted rule.
+		if (move.type !== "Normal") bp *= 1.2;
 		break;
 	case "stakeout": /* needs "switched in this turn" tracking; skipped */ break;
 	case "sheerforce":

--- a/sim/tools/strategic-ai/mechanics/MoveEvaluator.ts
+++ b/sim/tools/strategic-ai/mechanics/MoveEvaluator.ts
@@ -53,6 +53,12 @@ export interface MoveEvalContext {
 	 * Stomping Tantrum can be scored at their boosted value.
 	 */
 	attackerLastMoveFailed?: boolean;
+	/**
+	 * True when the defender is expected to have already taken damage
+	 * this turn — in doubles, an earlier-deciding partner committed to
+	 * a damaging move. Powers Assurance's 2× BP.
+	 */
+	defenderTookDamageThisTurn?: boolean;
 }
 
 /** Result of a move evaluation. */
@@ -116,10 +122,10 @@ export function evaluateMove(
 		// tracking would be expensive. Both have low false-positive
 		// cost — at worst a slightly over-scored Lash Out / Assurance.
 		attackerLostStatThisTurn: hasActiveNegativeBoost(attacker),
-		// In singles we don't track per-turn hits on the foe; leaving
-		// this `false` keeps Assurance honest (base BP) unless a future
-		// caller threads it in for doubles partner combos.
-		defenderTookDamageThisTurn: false,
+		// Singles callers leave this unset (Assurance stays at base
+		// BP); the doubles engine threads in "a partner already
+		// committed to attacking this turn".
+		defenderTookDamageThisTurn: ctx.defenderTookDamageThisTurn ?? false,
 	});
 	const maxHp = calc.defenderMaxHp || estimateMaxHp(fromTracked(defender));
 	const damageScore = (calc.avgDamage / Math.max(1, maxHp)) * 100; // 0..100ish

--- a/sim/tools/strategic-ai/mechanics/TransformPolicy.ts
+++ b/sim/tools/strategic-ai/mechanics/TransformPolicy.ts
@@ -30,9 +30,11 @@
  */
 import { Dex, toID } from "../../../dex";
 import type { Move } from "../../../dex-moves";
+import type { Species } from "../../../dex-species";
 import type { PokemonMoveRequestData } from "../../../side";
 import type { BattleStateTracker, TrackedPokemon } from "../state/BattleStateTracker";
 import { calculateDamage, fromTracked } from "./DamageCalc";
+import { evaluateMatchup } from "./SwitchEvaluator";
 
 /** Decision returned by {@link chooseTransform}. */
 export interface TransformDecision {
@@ -252,13 +254,78 @@ function considerZMove(input: TransformPolicyInput): TransformDecision | null {
 // Mega
 // -----------------------------------------------------------------------
 
+/**
+ * How much worse (in matchup-score units) the mega forme may look
+ * against the current foe before we defer the transformation to a
+ * later turn.
+ */
+const MEGA_DEFER_MARGIN = 8;
+
 function considerMega(input: TransformPolicyInput): TransformDecision | null {
-	const { active } = input;
-	if (active.canMegaEvo) return { suffix: " mega", rationale: "mega" };
-	if (active.canMegaEvoX) return { suffix: " megax", rationale: "mega-x" };
-	if (active.canMegaEvoY) return { suffix: " megay", rationale: "mega-y" };
-	if (active.canUltraBurst) return { suffix: " ultra", rationale: "ultra-burst" };
-	return null;
+	const { active, myMon, foeMon, tracker } = input;
+	let suffix: string | null = null;
+	let rationale = "mega";
+	if (active.canMegaEvo) suffix = " mega";
+	else if (active.canMegaEvoX) {
+		suffix = " megax";
+		rationale = "mega-x";
+	} else if (active.canMegaEvoY) {
+		suffix = " megay";
+		rationale = "mega-y";
+	} else if (active.canUltraBurst) {
+		suffix = " ultra";
+		rationale = "ultra-burst";
+	}
+	if (!suffix) return null;
+	// Mega is nearly free power, but a few formes trade away a
+	// load-bearing ability or typing for this exact matchup (losing
+	// Levitate into an Earthquake user, dropping an Intimidate drop,
+	// gaining a 4× weakness to the foe's STAB). Compare matchup scores
+	// and defer when the mega forme is clearly worse *right now* — the
+	// one-shot resource stays available for a better turn.
+	const megaForme = megaTargetForme(myMon);
+	if (megaForme) {
+		const current = evaluateMatchup(myMon, foeMon, tracker).score;
+		const asMega = evaluateMatchup(projectForme(myMon, megaForme), foeMon, tracker).score;
+		if (asMega < current - MEGA_DEFER_MARGIN) return null;
+	}
+	return { suffix, rationale };
+}
+
+/**
+ * Resolve the forme `mon` would mega-evolve / ultra-burst into, via
+ * its held stone.
+ *
+ * @param mon The tracked mon holding a Mega Stone / Ultranecrozium Z.
+ * @returns The target forme's species data, or `null` when unknown.
+ */
+function megaTargetForme(mon: TrackedPokemon): Species | null {
+	const item = Dex.items.get(toID(mon.item));
+	if (!item?.exists) return null;
+	const formeName = item.megaStone ??
+		(item.id === "ultranecroziumz" ? "Necrozma-Ultra" : "");
+	if (!formeName) return null;
+	const forme = Dex.species.get(formeName);
+	return forme?.exists ? forme : null;
+}
+
+/**
+ * Project a tracked mon into another forme for matchup what-ifs. The
+ * known stat block is dropped so the matchup math re-estimates from
+ * the forme's base stats; boosts / HP / status carry over.
+ *
+ * @param mon The current tracked mon.
+ * @param forme The forme to project into.
+ * @returns A synthetic snapshot usable by {@link evaluateMatchup}.
+ */
+function projectForme(mon: TrackedPokemon, forme: Species): TrackedPokemon {
+	return {
+		...mon,
+		species: forme.name,
+		types: [...forme.types],
+		ability: toID(forme.abilities?.["0"] ?? ""),
+		stats: undefined,
+	};
 }
 
 // -----------------------------------------------------------------------

--- a/sim/tools/strategic-ai/policy/DifficultyPolicy.ts
+++ b/sim/tools/strategic-ai/policy/DifficultyPolicy.ts
@@ -2,19 +2,25 @@
  * Strategic-AI difficulty policy.
  *
  * Maps the user-visible `difficulty` integer (1..5) to a concrete
- * engine instance plus the per-engine knobs (epsilon-greedy noise,
- * info-forgetting). Centralising this here lets us tune each tier
- * without touching the engines themselves.
+ * engine instance plus the per-engine knobs (move-ladder advance cap,
+ * info-forgetting, switch margin). Centralising this here lets us tune
+ * each tier without touching the engines themselves.
  *
  * Mapping (matches the project plan):
  *
- * | difficulty | engine        | noise epsilon | info forgetting |
- * |-----------:|:--------------|:--------------|:----------------|
- * | 1          | RandomEngine  | 1.0           | 1.0             |
- * | 2          | LightEngine   | 0.30          | 0.50            |
- * | 3          | HeuristicE.   | 0.10          | 0.20            |
- * | 4          | OnePly (TBD)  | 0.05          | 0.10            |
- * | 5          | MCTS (TBD)    | 0.00          | 0.00            |
+ * | difficulty | engine        | ladder cap | info forgetting | switch margin |
+ * |-----------:|:--------------|:-----------|:----------------|:--------------|
+ * | 1          | RandomEngine  | 0.50       | 1.0             | 18            |
+ * | 2          | LightEngine   | 0.50       | 0.50            | 14            |
+ * | 3          | HeuristicE.   | 0.50       | 0.20            | 10            |
+ * | 4          | OnePly        | 0.30       | 0.10            | 6             |
+ * | 5          | MCTS          | 0.12       | 0.00            | 4             |
+ *
+ * The ladder cap bounds the per-step "slip to the next-best move"
+ * probability ({@link selectByScoreLadder}); difficulty 5 is
+ * near-greedy. The switch margin is how much better a bench mon's
+ * matchup must score before a voluntary switch fires (boss tiers
+ * switch on smaller edges, pokerogue-style).
  *
  * The `engine` option on `PlayerAIOptions` can force any tier to a
  * specific engine for tooling / testing.
@@ -39,33 +45,34 @@ export type EngineName =
 
 /** Per-tier knobs applied to {@link EngineContext}. */
 export interface DifficultyKnobs {
-	noiseEpsilon: number;
+	ladderAdvanceCap: number;
 	infoForgetting: number;
+	switchMargin: number;
 	searchBudgetMs?: number;
 }
 
-/** Compute the noise/info-forgetting knobs for a difficulty level. */
+/** Compute the ladder/info-forgetting/switch knobs for a difficulty level. */
 export function knobsForDifficulty(difficulty: number): DifficultyKnobs {
 	switch (difficulty) {
-		case 1:
-			return { noiseEpsilon: 1.0, infoForgetting: 1.0 };
-		case 2:
-			return { noiseEpsilon: 0.30, infoForgetting: 0.50 };
-		case 3:
-			return { noiseEpsilon: 0.10, infoForgetting: 0.20 };
-		case 4:
-			return { noiseEpsilon: 0.05, infoForgetting: 0.10, searchBudgetMs: 100 };
-		case 5:
-			return { noiseEpsilon: 0.0, infoForgetting: 0.0, searchBudgetMs: 200 };
-		default:
-			return { noiseEpsilon: 0.10, infoForgetting: 0.20 };
+	case 1:
+		return { ladderAdvanceCap: 0.50, infoForgetting: 1.0, switchMargin: 18 };
+	case 2:
+		return { ladderAdvanceCap: 0.50, infoForgetting: 0.50, switchMargin: 14 };
+	case 3:
+		return { ladderAdvanceCap: 0.50, infoForgetting: 0.20, switchMargin: 10 };
+	case 4:
+		return { ladderAdvanceCap: 0.30, infoForgetting: 0.10, switchMargin: 6, searchBudgetMs: 100 };
+	case 5:
+		// Fully greedy: no move-selection noise at max difficulty.
+		return { ladderAdvanceCap: 0, infoForgetting: 0.0, switchMargin: 4, searchBudgetMs: 200 };
+	default:
+		return { ladderAdvanceCap: 0.50, infoForgetting: 0.20, switchMargin: 10 };
 	}
 }
 
 /**
  * Produce a fresh engine for `difficulty`, optionally overridden by
- * the explicit `engine` name. Search tiers (`oneply`, `mcts`) fall back
- * to the heuristic engine until those phases land.
+ * the explicit `engine` name.
  */
 export function pickEngine(
 	difficulty: number,
@@ -73,19 +80,19 @@ export function pickEngine(
 ): Engine {
 	const resolved = engine === "auto" ? autoFor(difficulty) : engine;
 	switch (resolved) {
-		case "random":
-			return new RandomEngine();
-		case "light":
-			return new LightHeuristicEngine();
-		case "heuristic":
-			return new HeuristicEngine();
-		case "oneply":
-			return new OnePlySearchEngine();
-		case "mcts":
-			return new MctsEngine();
-		default:
-			// Unknown engine string: behave like tier 3.
-			return new HeuristicEngine();
+	case "random":
+		return new RandomEngine();
+	case "light":
+		return new LightHeuristicEngine();
+	case "heuristic":
+		return new HeuristicEngine();
+	case "oneply":
+		return new OnePlySearchEngine();
+	case "mcts":
+		return new MctsEngine();
+	default:
+		// Unknown engine string: behave like tier 3.
+		return new HeuristicEngine();
 	}
 }
 
@@ -102,7 +109,8 @@ function autoFor(difficulty: number): Exclude<EngineName, "auto"> {
  */
 export function applyKnobs(ctx: EngineContext, difficulty: number): void {
 	const knobs = knobsForDifficulty(difficulty);
-	ctx.noiseEpsilon = knobs.noiseEpsilon;
+	ctx.ladderAdvanceCap = knobs.ladderAdvanceCap;
 	ctx.infoForgetting = knobs.infoForgetting;
+	ctx.switchMargin = knobs.switchMargin;
 	if (knobs.searchBudgetMs) ctx.searchBudgetMs = knobs.searchBudgetMs;
 }

--- a/sim/tools/strategic-ai/policy/DifficultyPolicy.ts
+++ b/sim/tools/strategic-ai/policy/DifficultyPolicy.ts
@@ -14,11 +14,11 @@
  * | 2          | LightEngine   | 0.50       | 0.50            | 14            |
  * | 3          | HeuristicE.   | 0.50       | 0.20            | 10            |
  * | 4          | OnePly        | 0.30       | 0.10            | 6             |
- * | 5          | MCTS          | 0.12       | 0.00            | 4             |
+ * | 5          | MCTS          | 0.00       | 0.00            | 4             |
  *
  * The ladder cap bounds the per-step "slip to the next-best move"
- * probability ({@link selectByScoreLadder}); difficulty 5 is
- * near-greedy. The switch margin is how much better a bench mon's
+ * probability ({@link selectByScoreLadder}); difficulty 5 is fully
+ * greedy (no move-selection noise). The switch margin is how much better a bench mon's
  * matchup must score before a voluntary switch fires (boss tiers
  * switch on smaller edges, pokerogue-style).
  *
@@ -112,5 +112,8 @@ export function applyKnobs(ctx: EngineContext, difficulty: number): void {
 	ctx.ladderAdvanceCap = knobs.ladderAdvanceCap;
 	ctx.infoForgetting = knobs.infoForgetting;
 	ctx.switchMargin = knobs.switchMargin;
-	if (knobs.searchBudgetMs) ctx.searchBudgetMs = knobs.searchBudgetMs;
+	// Always assign so a reused EngineContext can't inherit a prior tier's
+	// budget; `options.searchBudgetMs` is re-applied by the caller afterward,
+	// and readers fall back to DEFAULT_BUDGET_MS when this is undefined.
+	ctx.searchBudgetMs = knobs.searchBudgetMs;
 }

--- a/sim/tools/strategic-ai/state/BattleStateTracker.ts
+++ b/sim/tools/strategic-ai/state/BattleStateTracker.ts
@@ -73,6 +73,14 @@ export interface TrackedPokemon {
 	item?: string;
 	/** Set of move ids the opponent has been observed using. */
 	revealedMoves: Set<string>;
+	/**
+	 * Move *types* this mon has proven immune to in a way its known
+	 * types don't explain (a `|-immune|` against a type-chart-neutral
+	 * hit). Signals a hidden immunity ability (Levitate, Flash Fire,
+	 * Volt/Water Absorb, Sap Sipper, ...) or item (Air Balloon) that
+	 * {@link OpponentInference} folds into its distributions.
+	 */
+	inferredImmunities: Set<string>;
 	/** Last move used (id), if any. */
 	lastMove?: string;
 	/**
@@ -294,6 +302,7 @@ export class BattleStateTracker {
 			types: [],
 			terastallized: false,
 			revealedMoves: new Set(),
+			inferredImmunities: new Set(),
 			lastMoveFailed: false,
 			sameMoveStreak: 0,
 			choiceLocked: false,
@@ -430,366 +439,392 @@ export class BattleStateTracker {
 	 */
 	applyEvent(event: BattleEvent): void {
 		switch (event.kind) {
-			case "turn":
-				this.turn = event.turn;
-				this.tickTimedConditions();
-				this._lastMover = null;
-				return;
-			case "gametype":
-				this.gametype = event.gametype;
-				return;
-			case "gen":
-				this.gen = event.gen;
-				return;
-			case "battlestart":
-				this.started = true;
-				return;
-			case "win":
-				this.ended = true;
-				this.winner = event.side ?? null;
-				this.winnerName = event.name ?? null;
-				return;
-			case "tie":
-				this.ended = true;
-				this.winner = null;
-				this.winnerName = null;
-				return;
-			case "move": {
-				const mon = this.resolveByRef(event.user);
-				const moveId = toID(event.move);
-				if (moveId) {
-					if (mon.lastMove === moveId) {
-						mon.sameMoveStreak += 1;
-					} else {
-						mon.sameMoveStreak = 1;
-					}
-					mon.lastMove = moveId;
-					mon.revealedMoves.add(moveId);
-					// A new move attempt clears the previous failure flag.
-					// We re-set it later if a `miss` / `immune` / `fail`
-					// follow-up event arrives for this same move.
-					mon.lastMoveFailed = false;
-					// Choice-lock inference: a foe locked into a single move
-					// for two consecutive turns while holding a Choice item
-					// (or one we haven't ruled out) must be Choice-locked.
-					if (event.user.side === this.foeSide && mon.sameMoveStreak >= 2) {
-						mon.choiceLocked = true;
-					}
+		case "turn":
+			this.turn = event.turn;
+			this.tickTimedConditions();
+			this._lastMover = null;
+			return;
+		case "gametype":
+			this.gametype = event.gametype;
+			return;
+		case "gen":
+			this.gen = event.gen;
+			return;
+		case "battlestart":
+			this.started = true;
+			return;
+		case "win":
+			this.ended = true;
+			this.winner = event.side ?? null;
+			this.winnerName = event.name ?? null;
+			return;
+		case "tie":
+			this.ended = true;
+			this.winner = null;
+			this.winnerName = null;
+			return;
+		case "move": {
+			const mon = this.resolveByRef(event.user);
+			const moveId = toID(event.move);
+			if (moveId) {
+				if (mon.lastMove === moveId) {
+					mon.sameMoveStreak += 1;
+				} else {
+					mon.sameMoveStreak = 1;
 				}
-				this._lastMover = mon;
-				return;
-			}
-			case "miss": {
-				// `event.source` is the attacker. When it's missing
-				// (older protocol), fall back to the most recent mover.
-				const mon = event.source ?
-					this.resolveByRef(event.source) :
-					this._lastMover;
-				if (mon) mon.lastMoveFailed = true;
-				return;
-			}
-			case "immune": {
-				// `event.pokemon` is the immune *target*; the failing
-				// attacker is the most recent mover.
-				if (this._lastMover) this._lastMover.lastMoveFailed = true;
-				return;
-			}
-			case "fail": {
-				// `event.pokemon` is the failing attacker (or status
-				// target whose move/status fizzled — close enough).
-				const mon = this.resolveByRef(event.pokemon);
-				mon.lastMoveFailed = true;
-				return;
-			}
-			case "switch":
-			case "drag": {
-				const mon = this.resolveByRef(event.pokemon);
-				// Switching out resets boosts, volatiles, and Choice lock.
-				const previous = this.getActive(event.pokemon.side, event.pokemon.position);
-				if (previous && previous.id !== mon.id) {
-					previous.active = false;
-					previous.position = -1;
-					previous.boosts = {};
-					previous.volatiles.clear();
-					previous.choiceLocked = false;
-					previous.sameMoveStreak = 0;
+				mon.lastMove = moveId;
+				mon.revealedMoves.add(moveId);
+				// A new move attempt clears the previous failure flag.
+				// We re-set it later if a `miss` / `immune` / `fail`
+				// follow-up event arrives for this same move.
+				mon.lastMoveFailed = false;
+				// Choice-lock inference: a foe locked into a single move
+				// for two consecutive turns while holding a Choice item
+				// (or one we haven't ruled out) must be Choice-locked.
+				if (event.user.side === this.foeSide && mon.sameMoveStreak >= 2) {
+					mon.choiceLocked = true;
 				}
-				mon.active = true;
-				mon.position = event.pokemon.position;
-				mon.species = (event.details || "").split(",")[0].trim() || mon.species;
-				const levelMatch = /L(\d+)/.exec(event.details || "");
-				if (levelMatch) mon.level = parseInt(levelMatch[1]) || mon.level;
-				mon.condition = `${event.hp || mon.condition}${event.status ? ` ${event.status}` : ""}`;
-				mon.hpFraction = parseHpFraction(mon.condition);
-				mon.status = event.status || "";
-				mon.boosts = {};
-				mon.volatiles.clear();
-				mon.choiceLocked = false;
-				mon.sameMoveStreak = 0;
+			}
+			this._lastMover = mon;
+			return;
+		}
+		case "miss": {
+			// `event.source` is the attacker. When it's missing
+			// (older protocol), fall back to the most recent mover.
+			const mon = event.source ?
+				this.resolveByRef(event.source) :
+				this._lastMover;
+			if (mon) mon.lastMoveFailed = true;
+			return;
+		}
+		case "immune": {
+			// `event.pokemon` is the immune *target*; the failing
+			// attacker is the most recent mover.
+			const mover = this._lastMover;
+			if (mover) mover.lastMoveFailed = true;
+			// Unexplained immunity: when the type chart says the
+			// attacker's move should have connected against the
+			// target's known types, the target is hiding an
+			// immunity ability (Levitate, Flash Fire, Volt/Water
+			// Absorb, Sap Sipper, ...) or an Air Balloon. Record
+			// the move type for `OpponentInference`. Explicit
+			// `[from] ability: ...` reveals are handled by the
+			// `ability` event that accompanies them.
+			if (mover?.lastMove && !event.from) {
+				const target = this.resolveByRef(event.pokemon);
+				const moveData = Dex.moves.get(mover.lastMove);
 				if (
-					isSideId(event.pokemon.side) &&
-					isValidActivePosition(event.pokemon.position)
+					moveData?.exists && moveData.category !== "Status" &&
+					target.types.length > 0 &&
+					Dex.getImmunity(moveData.type, target.types)
 				) {
-					this.active[event.pokemon.side][event.pokemon.position] = mon.id;
+					target.inferredImmunities.add(moveData.type);
 				}
-				return;
 			}
-			case "faint": {
-				const mon = this.resolveByRef(event.pokemon);
-				mon.fainted = true;
-				mon.active = false;
+			return;
+		}
+		case "fail": {
+			// `event.pokemon` is the failing attacker (or status
+			// target whose move/status fizzled — close enough).
+			const mon = this.resolveByRef(event.pokemon);
+			mon.lastMoveFailed = true;
+			return;
+		}
+		case "switch":
+		case "drag": {
+			const mon = this.resolveByRef(event.pokemon);
+			// Switching out resets boosts, volatiles, and Choice lock.
+			const previous = this.getActive(event.pokemon.side, event.pokemon.position);
+			if (previous && previous.id !== mon.id) {
+				previous.active = false;
+				previous.position = -1;
+				previous.boosts = {};
+				previous.volatiles.clear();
+				previous.choiceLocked = false;
+				previous.sameMoveStreak = 0;
+			}
+			mon.active = true;
+			mon.position = event.pokemon.position;
+			mon.species = (event.details || "").split(",")[0].trim() || mon.species;
+			const levelMatch = /L(\d+)/.exec(event.details || "");
+			if (levelMatch) mon.level = parseInt(levelMatch[1]) || mon.level;
+			mon.condition = `${event.hp || mon.condition}${event.status ? ` ${event.status}` : ""}`;
+			mon.hpFraction = parseHpFraction(mon.condition);
+			mon.status = event.status || "";
+			mon.boosts = {};
+			mon.volatiles.clear();
+			mon.choiceLocked = false;
+			mon.sameMoveStreak = 0;
+			if (
+				isSideId(event.pokemon.side) &&
+				isValidActivePosition(event.pokemon.position)
+			) {
+				this.active[event.pokemon.side][event.pokemon.position] = mon.id;
+			}
+			return;
+		}
+		case "faint": {
+			const mon = this.resolveByRef(event.pokemon);
+			mon.fainted = true;
+			mon.active = false;
+			mon.hpFraction = 0;
+			mon.condition = "0 fnt";
+			if (!isSideId(event.pokemon.side)) return;
+			this.sides[event.pokemon.side].fainted += 1;
+			const slotIdx = event.pokemon.position;
+			if (isValidActivePosition(slotIdx) && this.active[event.pokemon.side][slotIdx] === mon.id) {
+				this.active[event.pokemon.side][slotIdx] = "";
+			}
+			return;
+		}
+		case "damage":
+		case "heal":
+		case "sethp": {
+			const mon = this.resolveByRef(event.pokemon);
+			const hp = event.hp;
+			const status = (event as { status?: string }).status ?? "";
+			if (hp.endsWith("fnt") || hp === "0") {
 				mon.hpFraction = 0;
-				mon.condition = "0 fnt";
-				if (!isSideId(event.pokemon.side)) return;
-				this.sides[event.pokemon.side].fainted += 1;
-				const slotIdx = event.pokemon.position;
-				if (isValidActivePosition(slotIdx) && this.active[event.pokemon.side][slotIdx] === mon.id) {
-					this.active[event.pokemon.side][slotIdx] = "";
+			} else {
+				mon.hpFraction = parseHpFraction(`${hp}${status ? ` ${status}` : ""}`);
+			}
+			mon.condition = `${hp}${status ? ` ${status}` : ""}`;
+			if (status) mon.status = status;
+			return;
+		}
+		case "status": {
+			const mon = this.resolveByRef(event.pokemon);
+			mon.status = event.status;
+			return;
+		}
+		case "curestatus": {
+			const mon = this.resolveByRef(event.pokemon);
+			mon.status = "";
+			return;
+		}
+		case "boost":
+		case "unboost":
+		case "setboost": {
+			const mon = this.resolveByRef(event.pokemon);
+			const cur = mon.boosts[event.stat] || 0;
+			if (event.kind === "boost") {
+				mon.boosts[event.stat] = clampStage(cur + event.amount);
+			} else if (event.kind === "unboost") {
+				mon.boosts[event.stat] = clampStage(cur - event.amount);
+			} else {
+				mon.boosts[event.stat] = clampStage(event.amount);
+			}
+			return;
+		}
+		case "clearboost": {
+			const mon = this.resolveByRef(event.pokemon);
+			mon.boosts = {};
+			return;
+		}
+		case "clearallboost":
+			for (const mon of this.pokemon.values()) mon.boosts = {};
+			return;
+		case "clearpositiveboost": {
+			const mon = this.resolveByRef(event.target);
+			for (const k of Object.keys(mon.boosts)) {
+				if ((mon.boosts[k] || 0) > 0) mon.boosts[k] = 0;
+			}
+			return;
+		}
+		case "clearnegativeboost": {
+			const mon = this.resolveByRef(event.pokemon);
+			for (const k of Object.keys(mon.boosts)) {
+				if ((mon.boosts[k] || 0) < 0) mon.boosts[k] = 0;
+			}
+			return;
+		}
+		case "invertboost": {
+			const mon = this.resolveByRef(event.pokemon);
+			for (const k of Object.keys(mon.boosts)) {
+				mon.boosts[k] = -(mon.boosts[k] || 0);
+			}
+			return;
+		}
+		case "weather":
+			if (event.weather === "none" || event.upkeep) {
+				if (event.weather === "none") {
+					this.field.weather = "";
+					this.field.weatherTurns = 0;
 				}
-				return;
+			} else {
+				this.field.weather = toID(event.weather);
+				// Weather lasts 5 turns by default; 8 with the matching rock.
+				this.field.weatherTurns = 5;
 			}
-			case "damage":
-			case "heal":
-			case "sethp": {
-				const mon = this.resolveByRef(event.pokemon);
-				const hp = event.hp;
-				const status = (event as { status?: string }).status ?? "";
-				if (hp.endsWith("fnt") || hp === "0") {
-					mon.hpFraction = 0;
-				} else {
-					mon.hpFraction = parseHpFraction(`${hp}${status ? ` ${status}` : ""}`);
-				}
-				mon.condition = `${hp}${status ? ` ${status}` : ""}`;
-				if (status) mon.status = status;
-				return;
+			return;
+		case "fieldstart": {
+			const id = toID(event.condition);
+			if (id === "trickroom") {
+				this.field.trickRoom = true;
+				this.field.trickRoomTurns = 5;
+			} else if (id === "magicroom") {
+				this.field.magicRoom = true;
+			} else if (id === "wonderroom") {
+				this.field.wonderRoom = true;
+			} else if (id === "gravity") {
+				this.field.gravity = true;
+				this.field.gravityTurns = 5;
+			} else if (id === "electricterrain" || id === "grassyterrain" || id === "mistyterrain" || id === "psychicterrain") {
+				this.field.terrain = id;
+				this.field.terrainTurns = 5;
 			}
-			case "status": {
-				const mon = this.resolveByRef(event.pokemon);
-				mon.status = event.status;
-				return;
+			return;
+		}
+		case "fieldend": {
+			const id = toID(event.condition);
+			if (id === "trickroom") {
+				this.field.trickRoom = false;
+				this.field.trickRoomTurns = 0;
+			} else if (id === "magicroom") {
+				this.field.magicRoom = false;
+			} else if (id === "wonderroom") {
+				this.field.wonderRoom = false;
+			} else if (id === "gravity") {
+				this.field.gravity = false;
+				this.field.gravityTurns = 0;
+			} else if (id === this.field.terrain) {
+				this.field.terrain = "";
+				this.field.terrainTurns = 0;
 			}
-			case "curestatus": {
-				const mon = this.resolveByRef(event.pokemon);
-				mon.status = "";
-				return;
+			return;
+		}
+		case "sidestart": {
+			if (!isSideId(event.side)) return;
+			const ss = this.sides[event.side];
+			const id = toID(event.condition);
+			switch (id) {
+			case "stealthrock": ss.stealthRock = true; break;
+			case "spikes": ss.spikes = Math.min(3, ss.spikes + 1); break;
+			case "toxicspikes": ss.toxicSpikes = Math.min(2, ss.toxicSpikes + 1); break;
+			case "stickyweb": ss.stickyWeb = true; break;
+			case "reflect": ss.reflectTurns = 5; break;
+			case "lightscreen": ss.lightScreenTurns = 5; break;
+			case "auroraveil": ss.auroraVeilTurns = 5; break;
+			case "tailwind": ss.tailwindTurns = 4; break;
+			case "safeguard": ss.safeguardTurns = 5; break;
+			case "mist": ss.mistTurns = 5; break;
 			}
-			case "boost":
-			case "unboost":
-			case "setboost": {
-				const mon = this.resolveByRef(event.pokemon);
-				const cur = mon.boosts[event.stat] || 0;
-				if (event.kind === "boost") {
-					mon.boosts[event.stat] = clampStage(cur + event.amount);
-				} else if (event.kind === "unboost") {
-					mon.boosts[event.stat] = clampStage(cur - event.amount);
-				} else {
-					mon.boosts[event.stat] = clampStage(event.amount);
-				}
-				return;
+			return;
+		}
+		case "sideend": {
+			if (!isSideId(event.side)) return;
+			const ss = this.sides[event.side];
+			const id = toID(event.condition);
+			switch (id) {
+			case "stealthrock": ss.stealthRock = false; break;
+			case "spikes": ss.spikes = 0; break;
+			case "toxicspikes": ss.toxicSpikes = 0; break;
+			case "stickyweb": ss.stickyWeb = false; break;
+			case "reflect": ss.reflectTurns = 0; break;
+			case "lightscreen": ss.lightScreenTurns = 0; break;
+			case "auroraveil": ss.auroraVeilTurns = 0; break;
+			case "tailwind": ss.tailwindTurns = 0; break;
+			case "safeguard": ss.safeguardTurns = 0; break;
+			case "mist": ss.mistTurns = 0; break;
 			}
-			case "clearboost": {
-				const mon = this.resolveByRef(event.pokemon);
-				mon.boosts = {};
-				return;
+			return;
+		}
+		case "swapsideconditions": {
+			const tmp = this.sides[this.mySide];
+			this.sides[this.mySide] = this.sides[this.foeSide];
+			this.sides[this.foeSide] = tmp;
+			return;
+		}
+		case "ability": {
+			const mon = this.resolveByRef(event.pokemon);
+			mon.ability = toID(event.ability);
+			// Only seed `baseAbility` from a fresh, non-derived reveal.
+			// Trace / Imposter / Skill Swap / Role Play / etc. show up
+			// with an `event.from` describing the source effect; those
+			// expose the *acquired* ability, not the species' own.
+			if (!mon.baseAbility && !event.from) {
+				mon.baseAbility = mon.ability;
 			}
-			case "clearallboost":
-				for (const mon of this.pokemon.values()) mon.boosts = {};
-				return;
-			case "clearpositiveboost": {
-				const mon = this.resolveByRef(event.target);
-				for (const k of Object.keys(mon.boosts)) {
-					if ((mon.boosts[k] || 0) > 0) mon.boosts[k] = 0;
-				}
-				return;
+			return;
+		}
+		case "endability": {
+			const mon = this.resolveByRef(event.pokemon);
+			mon.ability = "";
+			return;
+		}
+		case "item": {
+			const mon = this.resolveByRef(event.pokemon);
+			mon.item = toID(event.item);
+			return;
+		}
+		case "enditem": {
+			const mon = this.resolveByRef(event.pokemon);
+			mon.item = "";
+			return;
+		}
+		case "transform": {
+			const mon = this.resolveByRef(event.pokemon);
+			mon.species = event.species;
+			return;
+		}
+		case "mega": {
+			const mon = this.resolveByRef(event.pokemon);
+			mon.volatiles.add("mega");
+			return;
+		}
+		case "primal": {
+			const mon = this.resolveByRef(event.pokemon);
+			mon.volatiles.add("primal");
+			return;
+		}
+		case "burst": {
+			const mon = this.resolveByRef(event.pokemon);
+			mon.species = event.species;
+			mon.volatiles.add("ultraburst");
+			return;
+		}
+		case "zpower": {
+			const mon = this.resolveByRef(event.pokemon);
+			mon.volatiles.add("zpower");
+			return;
+		}
+		case "terastallize": {
+			const mon = this.resolveByRef(event.pokemon);
+			mon.terastallized = true;
+			mon.teraType = event.type;
+			mon.types = [event.type];
+			return;
+		}
+		case "volatilestart": {
+			const mon = this.resolveByRef(event.pokemon);
+			mon.volatiles.add(toID(event.effect));
+			return;
+		}
+		case "volatileend": {
+			const mon = this.resolveByRef(event.pokemon);
+			mon.volatiles.delete(toID(event.effect));
+			return;
+		}
+		case "cant": {
+			const mon = this.resolveByRef(event.pokemon);
+			mon.sameMoveStreak = 0;
+			if (event.move) {
+				mon.revealedMoves.add(toID(event.move));
 			}
-			case "clearnegativeboost": {
-				const mon = this.resolveByRef(event.pokemon);
-				for (const k of Object.keys(mon.boosts)) {
-					if ((mon.boosts[k] || 0) < 0) mon.boosts[k] = 0;
-				}
-				return;
-			}
-			case "invertboost": {
-				const mon = this.resolveByRef(event.pokemon);
-				for (const k of Object.keys(mon.boosts)) {
-					mon.boosts[k] = -(mon.boosts[k] || 0);
-				}
-				return;
-			}
-			case "weather":
-				if (event.weather === "none" || event.upkeep) {
-					if (event.weather === "none") {
-						this.field.weather = "";
-						this.field.weatherTurns = 0;
-					}
-				} else {
-					this.field.weather = toID(event.weather);
-					// Weather lasts 5 turns by default; 8 with the matching rock.
-					this.field.weatherTurns = 5;
-				}
-				return;
-			case "fieldstart": {
-				const id = toID(event.condition);
-				if (id === "trickroom") {
-					this.field.trickRoom = true;
-					this.field.trickRoomTurns = 5;
-				} else if (id === "magicroom") {
-					this.field.magicRoom = true;
-				} else if (id === "wonderroom") {
-					this.field.wonderRoom = true;
-				} else if (id === "gravity") {
-					this.field.gravity = true;
-					this.field.gravityTurns = 5;
-				} else if (id === "electricterrain" || id === "grassyterrain" || id === "mistyterrain" || id === "psychicterrain") {
-					this.field.terrain = id;
-					this.field.terrainTurns = 5;
-				}
-				return;
-			}
-			case "fieldend": {
-				const id = toID(event.condition);
-				if (id === "trickroom") {
-					this.field.trickRoom = false;
-					this.field.trickRoomTurns = 0;
-				} else if (id === "magicroom") {
-					this.field.magicRoom = false;
-				} else if (id === "wonderroom") {
-					this.field.wonderRoom = false;
-				} else if (id === "gravity") {
-					this.field.gravity = false;
-					this.field.gravityTurns = 0;
-				} else if (id === this.field.terrain) {
-					this.field.terrain = "";
-					this.field.terrainTurns = 0;
-				}
-				return;
-			}
-			case "sidestart": {
-				if (!isSideId(event.side)) return;
-				const ss = this.sides[event.side];
-				const id = toID(event.condition);
-				switch (id) {
-					case "stealthrock": ss.stealthRock = true; break;
-					case "spikes": ss.spikes = Math.min(3, ss.spikes + 1); break;
-					case "toxicspikes": ss.toxicSpikes = Math.min(2, ss.toxicSpikes + 1); break;
-					case "stickyweb": ss.stickyWeb = true; break;
-					case "reflect": ss.reflectTurns = 5; break;
-					case "lightscreen": ss.lightScreenTurns = 5; break;
-					case "auroraveil": ss.auroraVeilTurns = 5; break;
-					case "tailwind": ss.tailwindTurns = 4; break;
-					case "safeguard": ss.safeguardTurns = 5; break;
-					case "mist": ss.mistTurns = 5; break;
-				}
-				return;
-			}
-			case "sideend": {
-				if (!isSideId(event.side)) return;
-				const ss = this.sides[event.side];
-				const id = toID(event.condition);
-				switch (id) {
-					case "stealthrock": ss.stealthRock = false; break;
-					case "spikes": ss.spikes = 0; break;
-					case "toxicspikes": ss.toxicSpikes = 0; break;
-					case "stickyweb": ss.stickyWeb = false; break;
-					case "reflect": ss.reflectTurns = 0; break;
-					case "lightscreen": ss.lightScreenTurns = 0; break;
-					case "auroraveil": ss.auroraVeilTurns = 0; break;
-					case "tailwind": ss.tailwindTurns = 0; break;
-					case "safeguard": ss.safeguardTurns = 0; break;
-					case "mist": ss.mistTurns = 0; break;
-				}
-				return;
-			}
-			case "swapsideconditions": {
-				const tmp = this.sides[this.mySide];
-				this.sides[this.mySide] = this.sides[this.foeSide];
-				this.sides[this.foeSide] = tmp;
-				return;
-			}
-			case "ability": {
-				const mon = this.resolveByRef(event.pokemon);
-				mon.ability = toID(event.ability);
-				// Only seed `baseAbility` from a fresh, non-derived reveal.
-				// Trace / Imposter / Skill Swap / Role Play / etc. show up
-				// with an `event.from` describing the source effect; those
-				// expose the *acquired* ability, not the species' own.
-				if (!mon.baseAbility && !event.from) {
-					mon.baseAbility = mon.ability;
-				}
-				return;
-			}
-			case "endability": {
-				const mon = this.resolveByRef(event.pokemon);
-				mon.ability = "";
-				return;
-			}
-			case "item": {
-				const mon = this.resolveByRef(event.pokemon);
-				mon.item = toID(event.item);
-				return;
-			}
-			case "enditem": {
-				const mon = this.resolveByRef(event.pokemon);
-				mon.item = "";
-				return;
-			}
-			case "transform": {
-				const mon = this.resolveByRef(event.pokemon);
-				mon.species = event.species;
-				return;
-			}
-			case "mega": {
-				const mon = this.resolveByRef(event.pokemon);
-				mon.volatiles.add("mega");
-				return;
-			}
-			case "primal": {
-				const mon = this.resolveByRef(event.pokemon);
-				mon.volatiles.add("primal");
-				return;
-			}
-			case "burst": {
-				const mon = this.resolveByRef(event.pokemon);
-				mon.species = event.species;
-				mon.volatiles.add("ultraburst");
-				return;
-			}
-			case "zpower": {
-				const mon = this.resolveByRef(event.pokemon);
-				mon.volatiles.add("zpower");
-				return;
-			}
-			case "terastallize": {
-				const mon = this.resolveByRef(event.pokemon);
-				mon.terastallized = true;
-				mon.teraType = event.type;
-				mon.types = [event.type];
-				return;
-			}
-			case "volatilestart": {
-				const mon = this.resolveByRef(event.pokemon);
-				mon.volatiles.add(toID(event.effect));
-				return;
-			}
-			case "volatileend": {
-				const mon = this.resolveByRef(event.pokemon);
-				mon.volatiles.delete(toID(event.effect));
-				return;
-			}
-			case "cant": {
-				const mon = this.resolveByRef(event.pokemon);
-				mon.sameMoveStreak = 0;
-				if (event.move) {
-					mon.revealedMoves.add(toID(event.move));
-				}
-				mon.lastMoveFailed = true;
-				return;
-			}
-			default:
-				// We deliberately ignore fail/miss/crit/immune/supereffective/
-				// resisted etc. for now. They're useful but the current heuristic
-				// engine doesn't act on them. Future extensions can hook here.
-				return;
+			mon.lastMoveFailed = true;
+			return;
+		}
+		case "crit":
+		case "supereffective":
+		case "resisted":
+			// These only print for hits that actually connected, so
+			// they confirm the most recent mover's attack landed —
+			// clear any stale failure flag (e.g. a `|-miss|` from an
+			// earlier strike of a multi-hit move).
+			if (this._lastMover) this._lastMover.lastMoveFailed = false;
+			return;
+		default:
+			return;
 		}
 	}
 
@@ -865,6 +900,11 @@ export class BattleStateTracker {
 	 * Compute hazard damage in HP fraction units when `mon` switches in
 	 * to its current position. Assumes the mon is on `side`. Returns 0
 	 * for Heavy-Duty Boots / Magic Guard / Levitate-on-spikes-only cases.
+	 *
+	 * Toxic Spikes don't deal entry damage, but the poison they inflict
+	 * costs real HP over the stay; we price that in as an expected-cost
+	 * fraction so switch evaluation stops treating a T-Spiked side as
+	 * free to pivot across.
 	 */
 	hazardDamageFraction(mon: TrackedPokemon, side: SideId): number {
 		if (mon.item === "heavydutyboots") return 0;
@@ -880,6 +920,17 @@ export class BattleStateTracker {
 			if (ss.spikes === 1) damage += 1 / 8;
 			else if (ss.spikes === 2) damage += 1 / 6;
 			else if (ss.spikes >= 3) damage += 1 / 4;
+			// One layer ≈ one psn tick (1/8); two layers inflict toxic,
+			// whose ramping damage prices higher. Grounded Poison-types
+			// absorb the spikes instead (cost 0), Steel / Immunity /
+			// already-statused mons can't be poisoned.
+			const poisonable = !mon.status &&
+				!mon.types.includes("Poison") &&
+				!mon.types.includes("Steel") &&
+				toID(mon.ability ?? "") !== "immunity";
+			if (ss.toxicSpikes > 0 && poisonable) {
+				damage += ss.toxicSpikes >= 2 ? 3 / 16 : 1 / 8;
+			}
 		}
 		return damage;
 	}

--- a/sim/tools/strategic-ai/state/OpponentInference.ts
+++ b/sim/tools/strategic-ai/state/OpponentInference.ts
@@ -18,9 +18,11 @@
  *   pick those up directly via the tracker. Otherwise, we limit guesses
  *   to legal abilities (`Dex.species.get(...).abilities`).
  * - **Move-set inference:** revealed moves come from the tracker; for
- *   the rest, we sample a uniform prior over the species' learnset as
- *   available in `Dex.data.Learnsets`. This module does not currently
- *   intersect that learnset with the active format's legal move pool.
+ *   the rest, we sample a uniform prior over the moves the species can
+ *   legally know *in the current gen at the mon's level* (level-up
+ *   moves above its level are excluded; machine / tutor / egg sources
+ *   are level-free). Species without current-gen learnset data fall
+ *   back to the full multi-gen learnset.
  *
  * The output is always a probability distribution over moves /
  * abilities / items, never a single guess. Search engines (one-ply,
@@ -97,8 +99,8 @@ export function topMoves(inf: FoeInference, n: number): string[] {
 // Internals
 // -----------------------------------------------------------------------
 
-/** Cache of legal-move arrays per species id. */
-const learnsetCache = new Map<string, string[]>();
+/** Cache of parsed learnsets per `${speciesId}|${gen}`. */
+const learnsetCache = new Map<string, LearnableMove[]>();
 
 function inferMoves(mon: TrackedPokemon): Distribution {
 	const dist: Distribution = new Map();
@@ -114,7 +116,7 @@ function inferMoves(mon: TrackedPokemon): Distribution {
 		dist.set(id, revealedShare / Math.max(1, revealed.length));
 	}
 	// Spread `remaining` over the species' legal moves we haven't seen yet.
-	const learnset = legalMoves(mon.species);
+	const learnset = legalMoves(mon);
 	const unseen = learnset.filter(m => !revealed.includes(m));
 	if (unseen.length === 0) {
 		// No unseen moves to absorb the remaining mass — renormalize the
@@ -136,6 +138,18 @@ function inferMoves(mon: TrackedPokemon): Distribution {
 	return dist;
 }
 
+/**
+ * Type-immunity abilities the `|-immune|` log signal can implicate,
+ * keyed by the immune move type. Shared by ability and item inference.
+ */
+const IMMUNITY_ABILITIES: Record<string, string[]> = {
+	Ground: ["levitate", "eartheater"],
+	Fire: ["flashfire", "wellbakedbody"],
+	Water: ["waterabsorb", "stormdrain", "dryskin"],
+	Electric: ["voltabsorb", "lightningrod", "motordrive"],
+	Grass: ["sapsipper"],
+};
+
 function inferAbilities(mon: TrackedPokemon): Distribution {
 	const dist: Distribution = new Map();
 	if (mon.ability) {
@@ -150,6 +164,19 @@ function inferAbilities(mon: TrackedPokemon): Distribution {
 	const choices = uniqueAbilityIds(species);
 	if (choices.length === 0) {
 		dist.set("", 1);
+		return dist;
+	}
+	// An observed unexplained immunity (tracker `|-immune|` analysis)
+	// pins the ability hard when the species can legally carry a
+	// matching immunity ability — e.g. a Ground "miss" on a non-Flying
+	// Bronzong is Levitate, full stop.
+	for (const type of mon.inferredImmunities) {
+		const candidates = IMMUNITY_ABILITIES[type]?.filter(a => choices.includes(a));
+		if (!candidates?.length) continue;
+		const per = 0.9 / candidates.length;
+		for (const id of candidates) dist.set(id, per);
+		const rest = choices.filter(c => !candidates.includes(c));
+		for (const id of rest) dist.set(id, 0.1 / rest.length);
 		return dist;
 	}
 	const per = 1 / choices.length;
@@ -194,9 +221,16 @@ function inferItems(tracker: BattleStateTracker, mon: TrackedPokemon): Distribut
 	if (species?.exists && species.nfe) evioliteScore += 0.6;
 
 	// Air Balloon: tracker emits `|-item|airballoon|` when the user is
-	// hit — we don't get a *miss* signal for ground moves currently, so
-	// we only weight balloon when the species is commonly seen with it.
-	if (species?.exists) {
+	// hit; before that the strongest signal is an *unexplained* Ground
+	// immunity from the `|-immune|` analysis — when the species can't
+	// legally run Levitate / Earth Eater, the balloon is the only
+	// remaining explanation. Otherwise fall back to the weak
+	// species-typing prior.
+	if (mon.inferredImmunities.has("Ground")) {
+		const legal = species?.exists ? uniqueAbilityIds(species) : [];
+		const abilityExplains = legal.some(a => IMMUNITY_ABILITIES.Ground.includes(a));
+		if (!abilityExplains) balloonScore += 0.8;
+	} else if (species?.exists) {
 		const tagged = species.types.includes("Electric") || species.types.includes("Steel");
 		if (tagged) balloonScore += 0.05;
 	}
@@ -226,29 +260,78 @@ function inferItems(tracker: BattleStateTracker, mon: TrackedPokemon): Distribut
 	return dist;
 }
 
-function legalMoves(species: string): string[] {
-	const id = toID(species);
-	const cached = learnsetCache.get(id);
+/** One learnable move with its current-gen availability. */
+interface LearnableMove {
+	id: string;
+	/** True when the move has at least one current-gen learn source. */
+	inGen: boolean;
+	/**
+	 * Lowest level the move becomes available at in the current gen.
+	 * 0 for level-free sources (machine / tutor / egg / event).
+	 */
+	minLevel: number;
+}
+
+/**
+ * Parse the species' learnset into {@link LearnableMove} records,
+ * cached per species+gen. Showdown stores learnsets by the *base*
+ * species (cosmetic forms share); sources are encoded like `9L36`
+ * (gen 9, level-up at 36), `9M` (machine), `8T` (tutor), `9E` (egg).
+ *
+ * @param species The species name or id to look up.
+ * @returns Every dex-valid move the species can know in any gen, with
+ *   current-gen availability metadata.
+ */
+function learnableMoves(species: string): LearnableMove[] {
+	const gen = Dex.gen;
+	const key = `${toID(species)}|${gen}`;
+	const cached = learnsetCache.get(key);
 	if (cached) return cached;
-	const result: string[] = [];
+	const result: LearnableMove[] = [];
 	const speciesObj = Dex.species.get(species);
 	if (!speciesObj?.exists) {
-		learnsetCache.set(id, result);
+		learnsetCache.set(key, result);
 		return result;
 	}
-	// Showdown stores learnsets by the *base* species (cosmetic forms
-	// share). We pull the dex's learnset map and accept anything from any
-	// gen the mon could have learned — close enough for inference.
 	const data = (Dex as unknown as { data: { Learnsets?: Record<string, { learnset?: Record<string, string[]> }> } }).data;
-	const ls = data?.Learnsets?.[id]?.learnset ?? data?.Learnsets?.[toID(speciesObj.baseSpecies)]?.learnset;
+	const ls = data?.Learnsets?.[toID(species)]?.learnset ??
+		data?.Learnsets?.[toID(speciesObj.baseSpecies)]?.learnset;
 	if (ls) {
-		for (const moveId of Object.keys(ls)) {
+		for (const [moveId, sources] of Object.entries(ls)) {
 			const mv: Move | undefined = Dex.moves.get(moveId);
-			if (mv?.exists) result.push(moveId);
+			if (!mv?.exists) continue;
+			let inGen = false;
+			let minLevel = Infinity;
+			for (const source of sources) {
+				const m = /^(\d+)([A-Z])(\d*)/.exec(source);
+				if (!m || parseInt(m[1]) !== gen) continue;
+				inGen = true;
+				const levelGate = m[2] === "L" ? parseInt(m[3]) || 0 : 0;
+				if (levelGate < minLevel) minLevel = levelGate;
+				if (minLevel === 0) break;
+			}
+			result.push({ id: moveId, inGen, minLevel: inGen ? minLevel : 0 });
 		}
 	}
-	learnsetCache.set(id, result);
+	learnsetCache.set(key, result);
 	return result;
+}
+
+/**
+ * Moves `mon` could legally know right now: current-gen sources only,
+ * with level-up moves above the mon's level excluded. Falls back to
+ * the full multi-gen learnset when the species has no current-gen
+ * data at all (custom formats / modded species).
+ *
+ * @param mon The tracked Pokemon whose move pool we're estimating.
+ * @returns Legal move ids for the prior distribution.
+ */
+function legalMoves(mon: TrackedPokemon): string[] {
+	const all = learnableMoves(mon.species);
+	const inGen = all.filter(m => m.inGen);
+	const pool = inGen.length > 0 ? inGen : all;
+	const level = mon.level || 100;
+	return pool.filter(m => m.minLevel <= level).map(m => m.id);
 }
 
 function uniqueAbilityIds(species: Species): string[] {

--- a/sim/tools/strategic-ai/state/OpponentInference.ts
+++ b/sim/tools/strategic-ai/state/OpponentInference.ts
@@ -73,7 +73,7 @@ export function inferFoeActive(tracker: BattleStateTracker): FoeInference | null
 
 /** Inference for an arbitrary tracked Pokemon (any side). */
 export function inferMon(tracker: BattleStateTracker, mon: TrackedPokemon): FoeInference {
-	const moves = inferMoves(mon);
+	const moves = inferMoves(mon, tracker.gen);
 	const abilities = inferAbilities(mon);
 	const items = inferItems(tracker, mon);
 	const hasBoots = (mon.item ? toID(mon.item) === "heavydutyboots" : (items.get("heavydutyboots") ?? 0) > 0.5);
@@ -102,7 +102,7 @@ export function topMoves(inf: FoeInference, n: number): string[] {
 /** Cache of parsed learnsets per `${speciesId}|${gen}`. */
 const learnsetCache = new Map<string, LearnableMove[]>();
 
-function inferMoves(mon: TrackedPokemon): Distribution {
+function inferMoves(mon: TrackedPokemon, gen: number): Distribution {
 	const dist: Distribution = new Map();
 	// Revealed moves get high mass.
 	const revealed = Array.from(mon.revealedMoves);
@@ -116,7 +116,7 @@ function inferMoves(mon: TrackedPokemon): Distribution {
 		dist.set(id, revealedShare / Math.max(1, revealed.length));
 	}
 	// Spread `remaining` over the species' legal moves we haven't seen yet.
-	const learnset = legalMoves(mon);
+	const learnset = legalMoves(mon, gen);
 	const unseen = learnset.filter(m => !revealed.includes(m));
 	if (unseen.length === 0) {
 		// No unseen moves to absorb the remaining mass — renormalize the
@@ -173,10 +173,15 @@ function inferAbilities(mon: TrackedPokemon): Distribution {
 	for (const type of mon.inferredImmunities) {
 		const candidates = IMMUNITY_ABILITIES[type]?.filter(a => choices.includes(a));
 		if (!candidates?.length) continue;
-		const per = 0.9 / candidates.length;
-		for (const id of candidates) dist.set(id, per);
 		const rest = choices.filter(c => !candidates.includes(c));
-		for (const id of rest) dist.set(id, 0.1 / rest.length);
+		if (rest.length === 0) {
+			// Every legal ability is an immunity candidate — spread the full
+			// mass over them so the distribution still sums to 1.
+			for (const id of candidates) dist.set(id, 1 / candidates.length);
+		} else {
+			for (const id of candidates) dist.set(id, 0.9 / candidates.length);
+			for (const id of rest) dist.set(id, 0.1 / rest.length);
+		}
 		return dist;
 	}
 	const per = 1 / choices.length;
@@ -279,11 +284,12 @@ interface LearnableMove {
  * (gen 9, level-up at 36), `9M` (machine), `8T` (tutor), `9E` (egg).
  *
  * @param species The species name or id to look up.
+ * @param gen The battle's generation, used to gate current-gen sources
+ *   and cache the parsed learnset per gen.
  * @returns Every dex-valid move the species can know in any gen, with
  *   current-gen availability metadata.
  */
-function learnableMoves(species: string): LearnableMove[] {
-	const gen = Dex.gen;
+function learnableMoves(species: string, gen: number): LearnableMove[] {
 	const key = `${toID(species)}|${gen}`;
 	const cached = learnsetCache.get(key);
 	if (cached) return cached;
@@ -324,10 +330,11 @@ function learnableMoves(species: string): LearnableMove[] {
  * data at all (custom formats / modded species).
  *
  * @param mon The tracked Pokemon whose move pool we're estimating.
+ * @param gen The battle's generation, threaded to the learnset lookup.
  * @returns Legal move ids for the prior distribution.
  */
-function legalMoves(mon: TrackedPokemon): string[] {
-	const all = learnableMoves(mon.species);
+function legalMoves(mon: TrackedPokemon, gen: number): string[] {
+	const all = learnableMoves(mon.species, gen);
 	const inGen = all.filter(m => m.inGen);
 	const pool = inGen.length > 0 ? inGen : all;
 	const level = mon.level || 100;


### PR DESCRIPTION
# Stronger Strategic AI: ~65% winrate at d5 vs d3, fix randombattle crash

## Summary

This PR overhauls the `strategic-ai` battle engine so higher difficulty levels are *measurably* stronger than lower ones, fixes a randombattle generation crash caused by host-side cosmetic skins, and adds a self-play harness so future AI changes can be validated empirically instead of by feel.

Headline numbers (1000-game seeded series, `gen9randombattle`, side-swapped):

| Matchup | Winrate (decisive) |
|---|---|
| **d5 vs d3** | **65.2%** (was ~50–58% pre-PR) |
| d5 vs d4 | 64.3% |
| d4 vs d2 | 59.3% |

A clean monotonic difficulty gradient, with the top tier now clearly separating from the heuristic core.

## What changed

### 1. Tracker is no longer starving the engines (the biggest single bug)

Before: `BattleStateTracker` only saw protocol log lines that flowed through `PlayerAI.receiveLine`. The PokeBedrock host bypasses that path (it has its own log interpreter), so engines were running blind to weather, hazards, boosts, status, revealed moves, and `lastMoveFailed`.

- New `PlayerAI.ingestLogLine(line)` API: feed the tracker without dispatching choices.
- New `Battle.forwardLogLineToAI` hook in `pokebedrock-beh`: routes every protocol line to its actor (with `|split|` privacy preserved).
- `EngineContext.lastMoveFailedByMon` now mirrors tracker state, so e.g. Stomping Tantrum doubles BP correctly after a fizzled Earthquake into Levitate.

### 2. MCTS tier (d5) does real multi-turn search

`MctsEngine` was a one-ply sampler in disguise. It now:

- Forks the live `Battle` via `toJSON()` / `fromJSON()` and plays out a few greedy turns against a determinized foe team.
- Samples a **fresh determinization per rollout** (weighted, without replacement) from a wider inferred-move pool, so visits average over many plausible foe sets instead of anchoring on one guess.
- Uses a **mostly-greedy foe reply model** at the root (real opponents — including our own d3 — play near-greedy).
- Evaluates fork end-states with a richer scoring function: HP + alive bonus *plus* status penalty, net stat-boost stages, and entry-hazard pressure (rocks/spikes/tspikes/web).
- **Blends** rollout score with the heuristic baseline (rather than overriding it) on a visit-count curve up to 60% rollout weight, so noisy rollouts can break ties but can't overturn a confident heuristic read.

### 3. MCTS now searches over **switches**, not just moves

`MctsEngine.maybeSwitchOut` wraps the heuristic switch gate with rollout verification:

- Heuristic says **switch** → vetoed when staying clearly wins (e.g. "we KO first" lines the matchup math misses).
- Heuristic says **stay** in a losing matchup → overridden when rollouts strongly favor the best bench mon.
- Asymmetric margins (12 to veto, 18 to override) and the existing switch lock prevent ping-pong.

This was the missing structural piece — switch decisions used to be 100% heuristic regardless of difficulty.

### 4. Disciplined play at high difficulty

A diagnostic run (d5 with search disabled) only scored 52.4% vs d3, proving the heuristic core was injecting handicaps even at max difficulty:

- 15% chance per turn of a **random Protect probe** — vetoed at d4–d5.
- **Forced anti-staleness rotation** that demoted the best move when the second-best was within 90% — vetoed at d4–d5 (repeating Earthquake is usually correct).
- d5 ladder cap dropped from `0.12` → **`0` (fully greedy)**.

Lower tiers keep all three for human-feeling variety.

### 5. Pokerogue-style switch margins replacing a coin flip

The old switch gate was a `(difficulty - 1) / 4` coin flip — even an "elite" trainer ignored half their correct switches at d3 and added pure noise at d4–d5. Now: a voluntary switch must beat the current matchup by a difficulty-scaled margin, raised further by a `switchCount` counter that climbs each time we switch and floors back down each time we commit to a move.

### 6. Move selection ladder replacing epsilon-uniform noise

`selectByScoreLadder` walks the descending-sorted move list and advances to the next-best with probability proportional to *closeness*, capped per difficulty. Variety is now strength-preserving: a close second is a frequent pick, a distant third is rare, a negative-scored move is never reached from a positive run.

### 7. `OpponentInference` upgrades

- Move priors are now filtered by **gen and level legality** (parses learnset sources like `9L36` / `9M`), so e.g. a level-50 Garchomp's prior pool no longer includes moves it can't yet have learned.
- New `inferredImmunities` field on `TrackedPokemon`: when a foe's attack is logged as `|-immune|` against a type the dex didn't predict, the inference layer now uses that to upgrade ability/item guesses (Levitate, Storm Drain, Air Balloon, etc.).
- Crit / SE / resisted log events feed the tracker's per-mon `lastMoveFailed` flag.

### 8. Damage calc gaps closed

- **Toxic Spikes**: correct fraction (1/16 / 1/8) and Poison-immune absorb logic.
- **Weight-based BP** (Low Kick, Grass Knot, Heavy Slam, Heat Crash) and **speed-based BP** (Gyro Ball, Electro Ball) now use exact tables instead of a sigmoid.
- **Last Respects** scales with fainted party members.
- **Doubles spread reduction** flagged through to the calc.

### 9. Mega/Tera matchup-aware transforms

`TransformPolicy.considerMega` now compares the current matchup score with the projected mega forme's score and defers transformation when significantly worse — no more "Mega evolved into a 4× weakness because the move score said attack."

### 10. Random-team generator no longer crashes on host-side skins

PokeBedrock event skins (`Torterra-StPatrick`, `Sableye-Sculk`, `Mimikyu-Raichu`, etc.) are registered as `cosmeticFormes` but have no dex entries/aliases. Vanilla Showdown's random team generator deliberately rolls a random cosmetic forme for variety, which previously crashed battle creation:

```
Error: Unidentified species: torterrastpatrick
```

`getForme` in `gen8`, `gen9`, and `gen9baby/teams.ts` now filters cosmetic forme samples through `dex.species.get(forme).exists`, so unresolvable host skins are silently dropped while real cosmetic formes (e.g. `Pikachu-Original`, `Gastrodon-East`) still rotate as before. Errored game count in self-play went from ~6% to 0%.

### 11. New: AI-vs-AI self-play harness

Added `sim/tools/selfplay.ts`. Pits two `PlayerAI` configurations against each other, side-swapped per game, with a `worker_threads` pool for parallelism (default: cores − 1).

Usage:
```bash
node dist/sim/tools/selfplay.js --a 5 --b 3 --games 1000 --quiet --seed 1234
node dist/sim/tools/selfplay.js --help
```

A 1000-game series now finishes in ~7 min on an M-series MacBook (was ~2h single-threaded). Per-game seeds are pre-derived from the run seed, so results are reproducible regardless of pool size or completion order. Includes a per-game wall-clock watchdog so a single deadlocked battle can't kill the series silently.

## What players in `pokebedrock-beh` will notice

Once `pokebedrock-beh` picks up the new package, in-game AI behaviour should change visibly:

- **Trainer fights feel sharper at higher difficulties.** Gym leaders, Elite Four, and other boss trainers (which now floor to high difficulty) will pick the best damaging move much more consistently, switch into resists at the right moments, and *stop* switching when staying is clearly correct (the old gate had them flip-flopping between two mons).
- **Fewer "wait, why did it click Protect?" moments.** The 15% random Protect probe is gone at d4–d5; Protect is now only used when the move evaluator actually scores it well (e.g. scouting a Choice user, stalling poison, opposing partner setup).
- **Mega evolutions and Terastallizing happen at sane times.** No more "Mega'd into the 4× weakness." The transform policy now checks the *post-transform* matchup score and defers when it's worse.
- **Harder boss/elite trainers via better team building.** Boss trainer parties are difficulty-scaled (EVs, natures, competitive movesets, held items) and floor to a minimum difficulty.
- **No more `Unidentified species` crashes** when a randombattle-format trainer rolls into a battle that would have previously selected a host skin.
- **Lower difficulties feel less random, not less smart.** Difficulty 0–3 keeps human-feeling variety (move ladder, occasional Protect, anti-staleness rotation), but the variety now comes from *picking among reasonable options* rather than rolling dice on whether to ignore a correct switch.
- **Status/boost/hazard awareness.** With the tracker now actually receiving log lines, AI decisions take into account weather/terrain, screens, hazards, opponent boosts, and burned/paralyzed mons — none of which were reaching the engines before.

The lower tiers were intentionally *not* hardened; players choosing easier opponents should still see plenty of suboptimal play, just suboptimal in a more intentional way.

## Test plan

- [x] `node build` clean.
- [x] `node dist/sim/tools/selfplay.js --a 5 --b 3 --games 1000 --quiet --seed 1234,5678,9012,3456` → 65.2% (target was ≥65%).
- [x] Difficulty gradient verified: d5 > d4 > d2 > d0 holds in 400-game runs.
- [x] No `Unidentified species` errors across 1000+ games of `gen9randombattle`.
- [x] Self-play watchdog: a deliberately deadlocked game is force-tied and the series completes.
- [ ] Smoke-test in `pokebedrock-beh` against an Elite Four trainer (visual) — recommended before merge.

## Risks / follow-ups

- The MCTS fork path requires `Battle.toJSON()` / `fromJSON()` and a host that exposes the live battle to the AI; falls back to the tracker-only sampler when unavailable. (Bedrock host wires this up; the self-play harness does too.)
- `searchBudgetMs` still defaults to 200ms at d5. Increasing to 500ms didn't change winrate within noise — the ceiling is rollout *quality*, not quantity. Future work: smarter rollout policy (use the real evaluator inside the fork instead of greedy max-BP).
- Doubles MCTS search isn't modelled (slot pairing is non-trivial); doubles still uses the heuristic engine.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented Random Battles from selecting cosmetic formes that can’t be resolved in the in-game dex (including baby variants).

* **New Features**
  * Added a deterministic AI self-play harness with a runnable CLI and optional worker-thread parallel execution.
  * Upgraded strategic AI with fork-based rollouts and ladder-style move selection, plus improved Mega/Ultra decision-making.

* **Improvements**
  * Refined switching logic, move-failure tracking, and hazard/damage estimations.
  * Improved opponent inference using inferred immunities and level-accurate learnset availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->