### PR TITLE
Add AI telemetry, SPRT, and baseline checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "build-npm": "node build && npx tsc sim/global-types.ts sim/index.ts --declaration --emitDeclarationOnly --declarationDir dist/ --target es2020 --strict --moduleResolution node --types node --lib es2020",
     "test-npm": "npx tsc sim/global-types.ts sim/index.ts --noEmit --target es2020 --strict --moduleResolution node --types node --lib es2020",
     "tsc": "tsc",
+    "ai:baseline": "sh sim/tools/strategic-ai/baselines/check.sh",
     "lint": "eslint --cache",
     "fix": "eslint --cache --fix",
     "full-lint": "npm run lint",

--- a/sim/teams.ts
+++ b/sim/teams.ts
@@ -170,6 +170,15 @@ export const Teams = new class Teams {
 			const id = this.packName(set.species || set.name);
 			buf += `|${this.packName(set.name || set.species) === id ? '' : id}`;
 
+			// uuid - @pokebedrock
+			buf += `|${set.uuid || ''}`;
+
+			// currentHealth - @pokebedrock
+			buf += `|${set.currentHealth ?? ''}`;
+
+			// status - @pokebedrock
+			buf += `|${set.status || ''}`;
+
 			// item
 			buf += `|${this.packName(set.item)}`;
 
@@ -178,6 +187,11 @@ export const Teams = new class Teams {
 
 			// moves
 			buf += '|' + set.moves.map(this.packName).join(',');
+
+			// movesInfo - @pokebedrock
+			buf += '|' + (set.movesInfo ?
+				set.movesInfo.map(info => `${info?.pp ?? ''}/${info?.maxPp ?? ''}`).join(',') :
+				'');
 
 			// nature
 			buf += `|${set.nature || ''}`;
@@ -288,7 +302,12 @@ export const Teams = new class Teams {
 			// currentHealth - @pokebedrock
 			j = buf.indexOf('|', i);
 			if (j < 0) return null;
-			set.currentHealth = parseInt(buf.substring(i, j));
+			// Absent on every set that isn't mid-battle (all vanilla ones),
+			// where `parseInt('')` is NaN. Leaving that in place round-trips
+			// the literal string "NaN" back out through `pack` and puts a
+			// NaN one `??` away from being read as real HP.
+			const currentHealth = parseInt(buf.substring(i, j));
+			if (Number.isFinite(currentHealth)) set.currentHealth = currentHealth;
 			i = j + 1;
 
 			// status - @pokebedrock
@@ -322,16 +341,22 @@ export const Teams = new class Teams {
 			// movesInfo - @pokebedrock
 			j = buf.indexOf('|', i);
 			if (j < 0) return null;
-			set.movesInfo = buf
-				.substring(i, j)
-				.split(',', 24)
-				.map(moveData => {
-					const moveInfo: AdditionalMoveInfo = {} as AdditionalMoveInfo;
-					const data = moveData.split('/');
-					moveInfo.pp = parseInt(data[0]);
-					moveInfo.maxPp = parseInt(data[1]);
-					return moveInfo;
-				});
+			if (j !== i) {
+				const movesInfo = buf
+					.substring(i, j)
+					.split(',', 24)
+					.map(moveData => {
+						const [pp, maxPp] = moveData.split('/').map(n => parseInt(n));
+						return { pp, maxPp } satisfies AdditionalMoveInfo;
+					});
+				// A partially-parsed entry is worse than none: `Pokemon`
+				// reads these with `?? basepp`, which does not catch NaN,
+				// so a single unparseable slot would leave that move on 0
+				// PP and the mon unable to act at all.
+				if (movesInfo.every(info => Number.isFinite(info.pp) && Number.isFinite(info.maxPp))) {
+					set.movesInfo = movesInfo;
+				}
+			}
 			i = j + 1;
 
 			// nature

--- a/sim/tools/ai-stats.ts
+++ b/sim/tools/ai-stats.ts
@@ -1,0 +1,226 @@
+/**
+ * Strength statistics for AI-vs-AI series: Elo conversion, confidence
+ * intervals, and a sequential probability ratio test (SPRT).
+ *
+ * Self-play winrates are noisy. A 100-game series that reports "52%"
+ * proves nothing — the 95% interval on 100 games is roughly ±10%, so
+ * that result is equally consistent with a 40-Elo gain and a 15-Elo
+ * loss. Two tools fix that:
+ *
+ *   - {@link scoreToElo} / {@link scoreInterval} report the *interval*,
+ *     so a summary can never claim a gain it didn't measure.
+ *   - {@link Sprt} runs the fixed-games series as a sequential test
+ *     instead: it stops as soon as the evidence clears an accept or
+ *     reject bound, which typically needs far fewer games than a
+ *     fixed-N design at the same error rates.
+ *
+ * The SPRT is the "generalized" (GSPRT) variant used by chess engine
+ * testing frameworks: rather than modelling win/draw/loss counts
+ * separately, it treats each game's score (1 / 0.5 / 0) as a sample
+ * from a distribution with unknown variance, estimates that variance
+ * from the series itself, and evaluates the normal-model
+ * log-likelihood ratio
+ *
+ *     LLR = N * (m1 - m0) * (2 * mean - m0 - m1) / (2 * variance)
+ *
+ * where `m0` / `m1` are the scores corresponding to the Elo bounds
+ * being tested. Draws therefore reduce variance (and so tighten the
+ * test) automatically, which matters a lot here because AI-vs-AI
+ * Pokemon series produce many force-tied games.
+ *
+ * @license MIT
+ */
+
+/** Per-game score for one contender: 1 win, 0.5 tie, 0 loss. */
+export type GameScore = 0 | 0.5 | 1;
+
+/** SPRT verdict. `"continue"` means not enough evidence yet. */
+export type SprtVerdict = "continue" | "accept-h1" | "accept-h0";
+
+/** Bounds and error rates defining an SPRT. */
+export interface SprtConfig {
+	/**
+	 * Elo gain under H0 — the hypothesis that the change is *not* an
+	 * improvement. Conventionally 0 ("no change").
+	 */
+	elo0: number;
+	/**
+	 * Elo gain under H1 — the smallest improvement worth detecting.
+	 * Larger values make the test cheaper but blind to small gains.
+	 */
+	elo1: number;
+	/** Type-I error rate (probability of wrongly accepting H1). */
+	alpha: number;
+	/** Type-II error rate (probability of wrongly accepting H0). */
+	beta: number;
+}
+
+/** A score estimate with a two-sided confidence interval. */
+export interface ScoreInterval {
+	/** Observed mean score in [0, 1]. */
+	score: number;
+	/** Lower bound of the confidence interval on the score. */
+	scoreLow: number;
+	/** Upper bound of the confidence interval on the score. */
+	scoreHigh: number;
+	/** {@link score} expressed as an Elo difference. */
+	elo: number;
+	/** Elo corresponding to {@link scoreLow}. */
+	eloLow: number;
+	/** Elo corresponding to {@link scoreHigh}. */
+	eloHigh: number;
+}
+
+/** Default SPRT: "is this at least +10 Elo?" at 5% error rates. */
+export const DEFAULT_SPRT: SprtConfig = { elo0: 0, elo1: 10, alpha: 0.05, beta: 0.05 };
+
+/**
+ * Convert an expected score to an Elo difference.
+ *
+ * @param score Expected score in [0, 1].
+ * @returns The Elo difference, clamped to +/-800 so a 100%/0% series
+ * reports a large finite number instead of +/-Infinity.
+ */
+export function scoreToElo(score: number): number {
+	if (score <= 0) return -800;
+	if (score >= 1) return 800;
+	const elo = -400 * Math.log10(1 / score - 1);
+	return Math.max(-800, Math.min(800, elo));
+}
+
+/**
+ * Convert an Elo difference to an expected score.
+ *
+ * @param elo The Elo difference.
+ * @returns The expected score in (0, 1).
+ */
+export function eloToScore(elo: number): number {
+	return 1 / (1 + 10 ** (-elo / 400));
+}
+
+/**
+ * Summarise a series of per-game scores as a score and Elo interval.
+ *
+ * Uses the normal approximation on the sample mean, which is
+ * well-behaved here because a series is many independent games. The
+ * variance is taken from the sample, so a draw-heavy series correctly
+ * reports a tighter interval than a decisive one.
+ *
+ * @param scores Per-game scores for the contender being rated.
+ * @param z Standard-normal quantile for the interval (1.96 = 95%).
+ * @returns The score/Elo point estimate with confidence bounds.
+ */
+export function scoreInterval(scores: readonly number[], z = 1.96): ScoreInterval {
+	const n = scores.length;
+	if (n === 0) {
+		return { score: 0.5, scoreLow: 0, scoreHigh: 1, elo: 0, eloLow: -800, eloHigh: 800 };
+	}
+	const mean = scores.reduce((a, b) => a + b, 0) / n;
+	const halfWidth = z * Math.sqrt(sampleVariance(scores, mean) / n);
+	const low = Math.max(0, mean - halfWidth);
+	const high = Math.min(1, mean + halfWidth);
+	return {
+		score: mean,
+		scoreLow: low,
+		scoreHigh: high,
+		elo: scoreToElo(mean),
+		eloLow: scoreToElo(low),
+		eloHigh: scoreToElo(high),
+	};
+}
+
+/**
+ * Sequential probability ratio test over per-game scores.
+ *
+ * Feed each game's score as it completes and stop the series as soon as
+ * {@link verdict} leaves `"continue"`. A run that never clears either
+ * bound is inconclusive — report the interval from
+ * {@link scoreInterval} rather than pretending the winrate is a result.
+ */
+export class Sprt {
+	/** Elo bounds and error rates this test was configured with. */
+	readonly config: SprtConfig;
+	private readonly m0: number;
+	private readonly m1: number;
+	private readonly upper: number;
+	private readonly lower: number;
+	private n = 0;
+	private sum = 0;
+	private sumSquares = 0;
+
+	/**
+	 * @param config Elo bounds and error rates. Defaults to
+	 * {@link DEFAULT_SPRT}.
+	 */
+	constructor(config: SprtConfig = DEFAULT_SPRT) {
+		this.config = config;
+		this.m0 = eloToScore(config.elo0);
+		this.m1 = eloToScore(config.elo1);
+		this.upper = Math.log((1 - config.beta) / config.alpha);
+		this.lower = Math.log(config.beta / (1 - config.alpha));
+	}
+
+	/** Number of games observed so far. */
+	get games(): number {
+		return this.n;
+	}
+
+	/**
+	 * Record one game's outcome.
+	 *
+	 * @param score The contender's score for that game (1 / 0.5 / 0).
+	 */
+	observe(score: number): void {
+		this.n++;
+		this.sum += score;
+		this.sumSquares += score * score;
+	}
+
+	/**
+	 * Current log-likelihood ratio.
+	 *
+	 * @returns The LLR, or 0 before enough games to estimate variance.
+	 */
+	llr(): number {
+		if (this.n < 2) return 0;
+		const mean = this.sum / this.n;
+		// Variance floor: an all-draws or all-wins prefix has zero
+		// sample variance, which would divide by zero and declare a
+		// verdict off two games.
+		const variance = Math.max(1e-4, (this.sumSquares / this.n) - (mean * mean));
+		return (this.n * (this.m1 - this.m0) * ((2 * mean) - this.m0 - this.m1)) / (2 * variance);
+	}
+
+	/**
+	 * Current verdict.
+	 *
+	 * @returns `"accept-h1"` once the LLR clears the upper bound,
+	 * `"accept-h0"` once it falls below the lower bound, else
+	 * `"continue"`.
+	 */
+	verdict(): SprtVerdict {
+		const llr = this.llr();
+		if (llr >= this.upper) return "accept-h1";
+		if (llr <= this.lower) return "accept-h0";
+		return "continue";
+	}
+
+	/** The LLR bounds `[reject, accept]` this test is walking between. */
+	bounds(): { lower: number, upper: number } {
+		return { lower: this.lower, upper: this.upper };
+	}
+}
+
+/**
+ * Sample variance of a score series.
+ *
+ * @param scores The per-game scores.
+ * @param mean The precomputed mean of `scores`.
+ * @returns The variance, floored above zero so callers can divide by it.
+ */
+function sampleVariance(scores: readonly number[], mean: number): number {
+	if (scores.length < 2) return 0.25;
+	let acc = 0;
+	for (const s of scores) acc += (s - mean) * (s - mean);
+	return Math.max(1e-6, acc / (scores.length - 1));
+}

--- a/sim/tools/player-ai.ts
+++ b/sim/tools/player-ai.ts
@@ -26,6 +26,7 @@ import {
 } from "./strategic-ai/policy/DifficultyPolicy";
 import { BattleStateTracker } from "./strategic-ai/state/BattleStateTracker";
 import { parseLine, type SideId } from "./strategic-ai/state/LogParser";
+import type { DecisionStats } from "./strategic-ai/telemetry/DecisionStats";
 
 /**
  * Construction options for {@link PlayerAI}.
@@ -58,6 +59,13 @@ export interface PlayerAIOptions {
 	 * pipe it through the standard `BattlePlayer` plumbing.
 	 */
 	engineInstance?: Engine;
+	/**
+	 * Opt-in decision telemetry (immune-move clicks, status-move usage,
+	 * switch rate, rejections). Costs one damage calculation per chosen
+	 * move, so production hosts leave it unset; the self-play harness
+	 * passes one per game.
+	 */
+	stats?: DecisionStats;
 }
 
 /**
@@ -78,6 +86,7 @@ export class PlayerAI extends BattlePlayer {
 	protected readonly engine: Engine;
 	protected readonly engineCtx: EngineContext;
 	protected tracker: BattleStateTracker | null = null;
+	protected readonly stats: DecisionStats | null;
 	private readonly pendingLogLines: string[] = [];
 
 	constructor(
@@ -88,6 +97,7 @@ export class PlayerAI extends BattlePlayer {
 		super(playerStream, debug);
 		this.prng = PRNG.get(options.seed ?? null);
 		this.difficulty = normaliseDifficulty(options.difficulty);
+		this.stats = options.stats ?? null;
 		this.engine = options.engineInstance ??
 			pickEngine(this.difficulty, options.engine ?? "auto");
 		this.engineCtx = {
@@ -101,6 +111,7 @@ export class PlayerAI extends BattlePlayer {
 			lastMoveFailedByMon: new Set(),
 			switchCount: 0,
 			ladderAdvanceCap: 0.5,
+			ladderRatioExponent: 1,
 			switchMargin: 10,
 			infoForgetting: 0,
 			searchBudgetMs: options.searchBudgetMs,
@@ -253,6 +264,7 @@ export class PlayerAI extends BattlePlayer {
 	 *   disabled for that mon and clear `lastMoveByMon` so we don't retry it.
 	 */
 	override receiveError(error: Error): void {
+		this.stats?.recordRejection();
 		const m1 = /^\[([^\]]+)\] ([^:]+): (.+)$/s.exec(error.message);
 		if (!m1) return;
 		const suffix = m1[1];
@@ -353,6 +365,8 @@ export class PlayerAI extends BattlePlayer {
 				}
 			}
 		}
-		return this.engine.choose(request, this.engineCtx);
+		const choice = this.engine.choose(request, this.engineCtx);
+		this.stats?.record(request, choice, this.tracker);
+		return choice;
 	}
 }

--- a/sim/tools/selfplay.ts
+++ b/sim/tools/selfplay.ts
@@ -23,6 +23,7 @@
  * @license MIT
  */
 
+import * as fs from "fs";
 import * as os from "os";
 import { Worker, isMainThread, parentPort, workerData } from "worker_threads";
 
@@ -30,7 +31,23 @@ import { type ObjectReadWriteStream } from "../../lib/streams";
 import * as BattleStreams from "../battle-stream";
 import { PRNG, type PRNGSeed } from "../prng";
 import type { ChoiceRequest } from "../side";
+import { Teams } from "../teams";
+import {
+	DEFAULT_SPRT,
+	Sprt,
+	scoreInterval,
+	type ScoreInterval,
+	type SprtConfig,
+	type SprtVerdict,
+} from "./ai-stats";
 import { PlayerAI, type PlayerAIOptions } from "./player-ai";
+import { ENGINE_NAMES, type EngineName } from "./strategic-ai/policy/DifficultyPolicy";
+import {
+	DecisionStats,
+	decisionRates,
+	emptyCounters,
+	type DecisionCounters,
+} from "./strategic-ai/telemetry/DecisionStats";
 
 /** One contender's configuration. */
 export interface ContenderConfig {
@@ -40,6 +57,18 @@ export interface ContenderConfig {
 	difficulty: number;
 	/** Optional search budget override (ms) for OnePly/MCTS tiers. */
 	searchBudgetMs?: number;
+	/**
+	 * Force a specific engine instead of the one the difficulty ladder
+	 * would pick.
+	 *
+	 * The point of this is an *absolute* yardstick. A tier-vs-tier score
+	 * only says whether d4 still beats d3; it says nothing about whether
+	 * either got stronger, so retuning both at once can look like "no
+	 * change" while the whole ladder sinks. Pinning one side to
+	 * `random` — which has no knobs and so cannot drift — gives a fixed
+	 * reference every tier can be scored against across revisions.
+	 */
+	engine?: EngineName;
 }
 
 /** Options for {@link runSelfPlay}. */
@@ -69,6 +98,22 @@ export interface SelfPlayOptions {
 	jobs?: number;
 	/** Log each game's result line to stdout. */
 	verbose?: boolean;
+	/**
+	 * Play games in mirrored pairs: the same two generated teams are
+	 * played twice with the contenders swapped between them. Both
+	 * contenders therefore pilot both teams, which removes team-quality
+	 * luck — by far the largest variance source in random-battle
+	 * formats — from the comparison.
+	 */
+	mirror?: boolean;
+	/**
+	 * Run the series as a sequential test and stop as soon as the
+	 * evidence clears a bound. `games` becomes the maximum, not the
+	 * target.
+	 */
+	sprt?: SprtConfig;
+	/** Collect per-decision telemetry (costs a damage calc per move). */
+	telemetry?: boolean;
 }
 
 /** Aggregated results returned by {@link runSelfPlay}. */
@@ -81,6 +126,16 @@ export interface SelfPlayResult {
 	winrateA: number;
 	avgTurns: number;
 	errors: number;
+	/**
+	 * A's score and Elo with a 95% confidence interval, counting ties
+	 * as half a point. This — not {@link winrateA} — is the number to
+	 * quote: it says how big the measured edge is *and* how sure we are.
+	 */
+	interval: ScoreInterval;
+	/** SPRT verdict, when `options.sprt` was set. */
+	sprt?: { verdict: SprtVerdict, llr: number, config: SprtConfig };
+	/** Per-decision counters per contender, when `options.telemetry` was set. */
+	telemetry?: { a: DecisionCounters, b: DecisionCounters };
 }
 
 /**
@@ -122,6 +177,8 @@ interface GameResult {
 	errored: boolean;
 	/** First stream error message, when `errored` is set. */
 	errorMessage?: string;
+	/** Per-contender decision counters, when telemetry was enabled. */
+	counters?: { a: DecisionCounters, b: DecisionCounters };
 }
 
 /** Everything a worker needs to play one game. Structured-cloneable. */
@@ -135,6 +192,14 @@ interface WorkerTask {
 	gameSeed: PRNGSeed;
 	maxTurns: number;
 	gameTimeoutMs: number;
+	/**
+	 * Packed teams for p1/p2. Always set by {@link runSelfPlay}: leaving
+	 * the team out makes the simulator generate one from a fresh crypto
+	 * seed, which silently defeats `--seed` reproducibility. Generating
+	 * teams up front also lets mirrored pairs reuse the same two teams.
+	 */
+	teams: { p1: string, p2: string };
+	telemetry: boolean;
 }
 
 /**
@@ -147,6 +212,8 @@ interface WorkerTask {
  * @param prng Run-level PRNG used to derive per-game seeds.
  * @param maxTurns Turn cap before forcing a tie.
  * @param gameTimeoutMs Wall-clock cap before the game is force-tied.
+ * @param teams Packed teams for p1 and p2.
+ * @param telemetry Whether to collect per-decision counters.
  * @returns The winner (by contender), turn count, and error flag.
  */
 async function playGame(
@@ -156,7 +223,9 @@ async function playGame(
 	b: ContenderConfig,
 	prng: PRNG,
 	maxTurns: number,
-	gameTimeoutMs: number
+	gameTimeoutMs: number,
+	teams: { p1: string, p2: string },
+	telemetry: boolean
 ): Promise<GameResult> {
 	const battleStream = new BattleStreams.BattleStream();
 	const streams = BattleStreams.getPlayerStreams(battleStream);
@@ -172,17 +241,22 @@ async function playGame(
 		prng.random(2 ** 16), prng.random(2 ** 16),
 	].join(",") as PRNGSeed;
 
+	const statsA = telemetry ? new DecisionStats() : undefined;
+	const statsB = telemetry ? new DecisionStats() : undefined;
 	const makeAI = (
 		stream: ObjectReadWriteStream<string>,
-		config: ContenderConfig
+		config: ContenderConfig,
+		stats: DecisionStats | undefined
 	) => new SelfPlayAI(stream, {
 		difficulty: config.difficulty,
 		searchBudgetMs: config.searchBudgetMs,
+		engine: config.engine,
 		seed: newSeed(),
+		stats,
 	} satisfies PlayerAIOptions);
 
-	const p1 = makeAI(streams.p1, aIsP1 ? a : b);
-	const p2 = makeAI(streams.p2, aIsP1 ? b : a);
+	const p1 = makeAI(streams.p1, aIsP1 ? a : b, aIsP1 ? statsA : statsB);
+	const p2 = makeAI(streams.p2, aIsP1 ? b : a, aIsP1 ? statsB : statsA);
 	// A crashed AI loop is the only signal that a game is unwinnable; surface
 	// it immediately instead of waiting for the force-tie/hang timers. A
 	// *successful* `start()` resolves at battle end (possibly before `consume`
@@ -199,8 +273,8 @@ async function playGame(
 	const p2Name = aIsP1 ? "Contender B" : "Contender A";
 	void streams.omniscient.write(
 		`>start ${JSON.stringify({ formatid: format, seed: newSeed() })}\n` +
-		`>player p1 ${JSON.stringify({ name: p1Name })}\n` +
-		`>player p2 ${JSON.stringify({ name: p2Name })}`
+		`>player p1 ${JSON.stringify({ name: p1Name, team: teams.p1 })}\n` +
+		`>player p2 ${JSON.stringify({ name: p2Name, team: teams.p2 })}`
 	);
 
 	let turns = 0;
@@ -260,9 +334,12 @@ async function playGame(
 		void streams.omniscient.writeEnd();
 	} catch {}
 
-	if (!winnerName) return { winner: null, turns, errored, errorMessage };
+	const counters = statsA && statsB ?
+		{ a: statsA.snapshot(), b: statsB.snapshot() } :
+		undefined;
+	if (!winnerName) return { winner: null, turns, errored, errorMessage, counters };
 	const winner = winnerName === "Contender A" ? "a" : winnerName === "Contender B" ? "b" : null;
-	return { winner, turns, errored, errorMessage };
+	return { winner, turns, errored, errorMessage, counters };
 }
 
 /**
@@ -276,13 +353,13 @@ async function playGame(
  */
 async function playGameWithRetries(task: WorkerTask): Promise<GameResult> {
 	const prng = PRNG.get(task.gameSeed);
-	let result = await playGame(
-		task.format, task.aIsP1, task.a, task.b, prng, task.maxTurns, task.gameTimeoutMs
+	const play = () => playGame(
+		task.format, task.aIsP1, task.a, task.b, prng,
+		task.maxTurns, task.gameTimeoutMs, task.teams, task.telemetry
 	);
+	let result = await play();
 	for (let attempt = 0; result.errored && result.turns === 0 && attempt < 3; attempt++) {
-		result = await playGame(
-			task.format, task.aIsP1, task.a, task.b, prng, task.maxTurns, task.gameTimeoutMs
-		);
+		result = await play();
 	}
 	return result;
 }
@@ -295,11 +372,14 @@ async function playGameWithRetries(task: WorkerTask): Promise<GameResult> {
  * @param tasks The games to play.
  * @param jobs Pool size (number of concurrent worker threads).
  * @param onResult Called once per task as results arrive (any order).
+ * @param shouldStop Polled before each task is claimed; returning true
+ * drains the pool without starting further games (SPRT early stop).
  */
 async function runWithWorkerPool(
 	tasks: WorkerTask[],
 	jobs: number,
-	onResult: (index: number, result: GameResult) => void
+	onResult: (index: number, result: GameResult) => void,
+	shouldStop: () => boolean = () => false
 ): Promise<void> {
 	let next = 0;
 	const spawn = () => new Worker(__filename, { workerData: { selfPlayWorker: true } });
@@ -332,7 +412,7 @@ async function runWithWorkerPool(
 
 	const lane = async () => {
 		let worker = spawn();
-		while (next < tasks.length) {
+		while (next < tasks.length && !shouldStop()) {
 			const task = tasks[next++];
 			try {
 				onResult(task.index, await runOne(worker, task));
@@ -360,29 +440,47 @@ async function runWithWorkerPool(
  * @returns Aggregate winrates and stats for the series.
  */
 export async function runSelfPlay(options: SelfPlayOptions): Promise<SelfPlayResult> {
-	const games = options.games ?? 50;
+	const maxGames = options.games ?? 50;
 	const format = options.format ?? "gen9randombattle";
 	const maxTurns = options.maxTurns ?? 500;
 	const gameTimeoutMs = options.gameTimeoutMs ?? 60_000;
 	const jobs = Math.max(1, options.jobs ?? defaultJobs());
+	const telemetry = !!options.telemetry;
+	const mirror = !!options.mirror;
 	const prng = PRNG.get(options.seed ?? null);
+	const newSeed = (): PRNGSeed => [
+		prng.random(2 ** 16), prng.random(2 ** 16),
+		prng.random(2 ** 16), prng.random(2 ** 16),
+	].join(",") as PRNGSeed;
 
-	// Pre-derive every game's seed from the run PRNG so results are
-	// reproducible regardless of pool size or completion order.
+	// Mirrored series play each team pair twice, so the game count has to
+	// be even for every pair to complete.
+	const games = mirror ? Math.max(2, maxGames - (maxGames % 2)) : maxGames;
+
+	// Pre-derive every game's seed AND team from the run PRNG so results
+	// are reproducible regardless of pool size or completion order. The
+	// teams matter most: omitting them makes the simulator generate from
+	// a fresh crypto seed, which silently voids `--seed`.
 	const tasks: WorkerTask[] = [];
 	for (let i = 0; i < games; i++) {
+		const isSecondLeg = mirror && i % 2 === 1;
+		const teams = isSecondLeg ?
+			// Second leg of a mirrored pair: same two teams, swapped
+			// contenders. `aIsP1` flips below, so A now pilots the team
+			// B just played and vice versa.
+			tasks[i - 1].teams :
+			{ p1: generateTeam(format, newSeed()), p2: generateTeam(format, newSeed()) };
 		tasks.push({
 			index: i,
 			format,
 			aIsP1: i % 2 === 0,
 			a: options.a,
 			b: options.b,
-			gameSeed: [
-				prng.random(2 ** 16), prng.random(2 ** 16),
-				prng.random(2 ** 16), prng.random(2 ** 16),
-			].join(",") as PRNGSeed,
+			gameSeed: newSeed(),
 			maxTurns,
 			gameTimeoutMs,
+			teams,
+			telemetry,
 		});
 	}
 
@@ -392,6 +490,44 @@ export async function runSelfPlay(options: SelfPlayOptions): Promise<SelfPlayRes
 	let errors = 0;
 	let totalTurns = 0;
 	let completed = 0;
+	const counters = { a: emptyCounters(), b: emptyCounters() };
+	const sprt = options.sprt ? new Sprt(options.sprt) : null;
+	// SPRT observations are fed in task order, not completion order, so
+	// the stopping point is identical at any `--jobs`. Out-of-order
+	// results wait in `pending` until the contiguous prefix reaches them.
+	const pending = new Map<number, GameResult>();
+	let nextToScore = 0;
+	const scores: number[] = [];
+	let stopped = false;
+
+	const scoreOf = (result: GameResult) =>
+		result.winner === "a" ? 1 : result.winner === "b" ? 0 : 0.5;
+
+	const drain = () => {
+		while (pending.has(nextToScore)) {
+			const first = pending.get(nextToScore)!;
+			pending.delete(nextToScore);
+			// In mirrored mode a pair is one observation (average of both
+			// legs), which is what removes the team-luck variance.
+			if (!mirror) {
+				scores.push(scoreOf(first));
+				nextToScore++;
+			} else if (pending.has(nextToScore + 1)) {
+				const second = pending.get(nextToScore + 1)!;
+				pending.delete(nextToScore + 1);
+				scores.push((scoreOf(first) + scoreOf(second)) / 2);
+				nextToScore += 2;
+			} else {
+				// Wait for the pair's second leg.
+				pending.set(nextToScore, first);
+				return;
+			}
+			if (sprt) {
+				sprt.observe(scores[scores.length - 1]);
+				if (sprt.verdict() !== "continue") stopped = true;
+			}
+		}
+	};
 
 	const record = (index: number, result: GameResult) => {
 		completed++;
@@ -400,30 +536,81 @@ export async function runSelfPlay(options: SelfPlayOptions): Promise<SelfPlayRes
 		if (result.winner === "a") winsA++;
 		else if (result.winner === "b") winsB++;
 		else ties++;
+		if (result.counters) {
+			// Contender labels are already normalised inside playGame, so
+			// these fold together regardless of which side each played.
+			counters.a = mergeCounters(counters.a, result.counters.a);
+			counters.b = mergeCounters(counters.b, result.counters.b);
+		}
+		pending.set(index, result);
+		drain();
 		if (options.verbose) {
 			const tag = result.winner === "a" ? nameOf(options.a, "A") :
 				result.winner === "b" ? nameOf(options.b, "B") : "tie";
+			const llr = sprt ? `  LLR ${sprt.llr().toFixed(2)}` : "";
 			console.log(`[${completed}/${games}] game ${index + 1}: ${tag} in ${result.turns} turns` +
-				`${result.errored ? ` (errored: ${result.errorMessage})` : ""}`);
+				`${result.errored ? ` (errored: ${result.errorMessage})` : ""}${llr}`);
 		}
 	};
 
 	if (jobs === 1) {
-		for (const task of tasks) record(task.index, await playGameWithRetries(task));
+		for (const task of tasks) {
+			if (stopped) break;
+			record(task.index, await playGameWithRetries(task));
+		}
 	} else {
-		await runWithWorkerPool(tasks, jobs, record);
+		await runWithWorkerPool(tasks, jobs, record, () => stopped);
 	}
 
 	const decisive = winsA + winsB;
+	const played = winsA + winsB + ties;
 	return {
-		games,
+		games: played,
 		winsA,
 		winsB,
 		ties,
 		winrateA: decisive > 0 ? winsA / decisive : 0.5,
-		avgTurns: games > 0 ? totalTurns / games : 0,
+		avgTurns: played > 0 ? totalTurns / played : 0,
 		errors,
+		interval: scoreInterval(scores),
+		...(sprt ? { sprt: { verdict: sprt.verdict(), llr: sprt.llr(), config: sprt.config } } : {}),
+		...(telemetry ? { telemetry: counters } : {}),
 	};
+}
+
+/**
+ * Generate and pack one team for a format.
+ *
+ * @param format Format id (must have a random team generator).
+ * @param seed Seed for the generator, so the team is reproducible.
+ * @returns The packed team string.
+ * @throws if the format has no team generator, since a strength series
+ * without fixed teams can be neither seeded nor mirrored.
+ */
+function generateTeam(format: string, seed: PRNGSeed): string {
+	try {
+		return Teams.pack(Teams.generate(format, { seed }));
+	} catch (err) {
+		throw new Error(
+			`Cannot generate a team for format "${format}": ${(err as Error).message}. ` +
+			`The self-play harness needs a format with a random team generator ` +
+			`(e.g. gen9randombattle, gen9randomdoublesbattle).`
+		);
+	}
+}
+
+/**
+ * Add two counter sets.
+ *
+ * @param into The accumulated counters.
+ * @param from The counters to add.
+ * @returns A new summed counter set.
+ */
+function mergeCounters(into: DecisionCounters, from: DecisionCounters): DecisionCounters {
+	const stats = new DecisionStats();
+	stats.merge(into);
+	stats.merge(from);
+	return stats.snapshot();
 }
 
 /**
@@ -501,10 +688,22 @@ if (require.main === module && isMainThread) {
 			`  --seed <n,n,n,n>  Run seed for reproducibility\n` +
 			`  --budget-a <ms>   Search budget override for A\n` +
 			`  --budget-b <ms>   Search budget override for B\n` +
+			`  --engine-a <id>   Force A's engine (${ENGINE_NAMES.join("|")})\n` +
+			`  --engine-b <id>   Force B's engine (fixed yardstick: random)\n` +
 			`  --max-turns <n>   Turn cap per game (default 500)\n` +
 			`  --game-timeout <ms>  Wall-clock cap per game before force-tie (default 60000)\n` +
 			`  --jobs <n>        Worker threads (default: cores - 1; 1 = inline)\n` +
-			`  --quiet           Suppress per-game lines`
+			`  --quiet           Suppress per-game lines\n` +
+			`  --mirror          Play mirrored pairs (same teams, swapped sides)\n` +
+			`  --sprt            Stop early once the result is significant\n` +
+			`  --elo0 <n>        SPRT null hypothesis in Elo (default 0)\n` +
+			`  --elo1 <n>        SPRT alternative hypothesis in Elo (default 10)\n` +
+			`  --alpha <p>       SPRT type-I error rate (default 0.05)\n` +
+			`  --beta <p>        SPRT type-II error rate (default 0.05)\n` +
+			`  --telemetry       Count immune/status/switch/rejection decisions\n` +
+			`  --out <path>      Write the result as JSON\n` +
+			`  --baseline <path> Compare against a saved run and exit 1 on regression\n` +
+			`  --write-baseline <path>  Save this run as the baseline`
 		);
 		process.exit(0);
 	}
@@ -526,33 +725,181 @@ if (require.main === module && isMainThread) {
 		}
 		return n;
 	};
+	const floatArg = (raw: string | undefined, name: string): number | undefined => {
+		if (raw === undefined) return undefined;
+		const n = Number(raw);
+		if (!Number.isFinite(n)) {
+			console.error(`Invalid --${name}: "${raw}" (expected a number)`);
+			process.exit(1);
+		}
+		return n;
+	};
+	const engineArg = (raw: string | undefined, name: string): EngineName | undefined => {
+		if (raw === undefined) return undefined;
+		if (!(ENGINE_NAMES as readonly string[]).includes(raw)) {
+			console.error(`Invalid --${name}: "${raw}" (expected ${ENGINE_NAMES.join("|")})`);
+			process.exit(1);
+		}
+		return raw as EngineName;
+	};
+	const format = args.format ?? "gen9randombattle";
 	const options: SelfPlayOptions = {
 		a: {
 			difficulty: intArg(args.a, "a", 0, 5) ?? 3,
 			searchBudgetMs: intArg(args["budget-a"], "budget-a", 0),
+			engine: engineArg(args["engine-a"], "engine-a"),
 		},
 		b: {
 			difficulty: intArg(args.b, "b", 0, 5) ?? 1,
 			searchBudgetMs: intArg(args["budget-b"], "budget-b", 0),
+			engine: engineArg(args["engine-b"], "engine-b"),
 		},
 		games: intArg(args.games, "games", 1),
-		format: args.format,
+		format,
 		seed: (args.seed as PRNGSeed | undefined) ?? null,
 		maxTurns: intArg(args["max-turns"], "max-turns", 1),
 		gameTimeoutMs: intArg(args["game-timeout"], "game-timeout", 0),
 		jobs: intArg(args.jobs, "jobs", 1),
 		verbose: !args.quiet,
+		mirror: !!args.mirror,
+		telemetry: !!args.telemetry,
+		sprt: args.sprt ? {
+			elo0: floatArg(args.elo0, "elo0") ?? DEFAULT_SPRT.elo0,
+			elo1: floatArg(args.elo1, "elo1") ?? DEFAULT_SPRT.elo1,
+			alpha: floatArg(args.alpha, "alpha") ?? DEFAULT_SPRT.alpha,
+			beta: floatArg(args.beta, "beta") ?? DEFAULT_SPRT.beta,
+		} : undefined,
 	};
 	void runSelfPlay(options).then(result => {
 		const aLabel = nameOf(options.a, "A");
 		const bLabel = nameOf(options.b, "B");
-		console.log(`\n=== Self-play: ${aLabel} vs ${bLabel} (${options.format ?? "gen9randombattle"}) ===`);
+		console.log(`\n=== Self-play: ${aLabel} vs ${bLabel} (${format}${options.mirror ? ", mirrored" : ""}) ===`);
 		console.log(`games:    ${result.games}`);
 		console.log(`${aLabel} wins: ${result.winsA}`);
 		console.log(`${bLabel} wins: ${result.winsB}`);
 		console.log(`ties:     ${result.ties}${result.errors ? `  (errors: ${result.errors})` : ""}`);
 		console.log(`winrate ${aLabel}: ${(result.winrateA * 100).toFixed(1)}% of decisive games`);
+		const iv = result.interval;
+		console.log(`score ${aLabel}:   ${(iv.score * 100).toFixed(1)}%  ` +
+			`[${(iv.scoreLow * 100).toFixed(1)}%, ${(iv.scoreHigh * 100).toFixed(1)}%] 95% CI`);
+		console.log(`elo ${aLabel}:     ${iv.elo >= 0 ? "+" : ""}${iv.elo.toFixed(0)}  ` +
+			`[${iv.eloLow.toFixed(0)}, ${iv.eloHigh.toFixed(0)}]`);
 		console.log(`avg turns: ${result.avgTurns.toFixed(1)}`);
-		process.exit(0);
+		if (result.sprt) {
+			const { verdict, llr, config } = result.sprt;
+			console.log(`sprt:      ${verdict} (LLR ${llr.toFixed(2)}, ` +
+				`H0 ${config.elo0} Elo vs H1 ${config.elo1} Elo)`);
+		}
+		if (result.telemetry) {
+			printTelemetry(aLabel, result.telemetry.a);
+			printTelemetry(bLabel, result.telemetry.b);
+		}
+		if (args.out) {
+			fs.writeFileSync(args.out, `${JSON.stringify({
+				format, mirror: !!options.mirror, seed: options.seed,
+				a: options.a, b: options.b, ...result,
+			}, null, "\t")}\n`);
+			console.log(`wrote ${args.out}`);
+		}
+		if (args["write-baseline"]) {
+			writeBaseline(args["write-baseline"], format, options, result);
+			console.log(`wrote baseline ${args["write-baseline"]}`);
+		}
+		process.exit(args.baseline ? checkBaseline(args.baseline, result) : 0);
 	});
+}
+
+/**
+ * Print one contender's decision telemetry.
+ *
+ * @param label The contender's display name.
+ * @param counters That contender's counters.
+ */
+function printTelemetry(label: string, counters: DecisionCounters): void {
+	const r = decisionRates(counters);
+	const pct = (v: number) => `${(v * 100).toFixed(1)}%`;
+	console.log(`telemetry ${label}: ${counters.decisions} decisions, ${counters.moves} moves`);
+	console.log(`  immune clicks   ${counters.immuneMoves} (${pct(r.immuneMoveRate)})` +
+		`  of which avoidable: ${counters.avoidableImmuneMoves} (${pct(r.avoidableImmuneMoveRate)})`);
+	console.log(`  zero-damage     ${counters.zeroDamageMoves} (${pct(r.zeroDamageMoveRate)})`);
+	console.log(`  resisted        ${counters.resistedMoves} (${pct(r.resistedMoveRate)})`);
+	console.log(`  status moves    ${counters.statusMoves} (${pct(r.statusMoveRate)})`);
+	console.log(`  switches        ${counters.switches} (${pct(r.switchRate)})`);
+	console.log(`  rejections      ${counters.rejections} (${pct(r.rejectionRate)})`);
+}
+
+/** A saved run, used as the regression reference for `--baseline`. */
+interface Baseline {
+	format: string;
+	mirror: boolean;
+	a: ContenderConfig;
+	b: ContenderConfig;
+	games: number;
+	/** A's mean score in the baseline run. */
+	score: number;
+	/** A's Elo in the baseline run. */
+	elo: number;
+	/** Lower 95% bound on A's score, i.e. the floor a rerun must clear. */
+	scoreLow: number;
+	created: string;
+}
+
+/**
+ * Save a run as a reusable baseline.
+ *
+ * @param path Where to write the baseline JSON.
+ * @param format The format the series ran.
+ * @param options The series options.
+ * @param result The series result.
+ */
+function writeBaseline(
+	path: string,
+	format: string,
+	options: SelfPlayOptions,
+	result: SelfPlayResult
+): void {
+	const baseline: Baseline = {
+		format,
+		mirror: !!options.mirror,
+		a: options.a,
+		b: options.b,
+		games: result.games,
+		score: result.interval.score,
+		elo: result.interval.elo,
+		scoreLow: result.interval.scoreLow,
+		created: new Date().toISOString(),
+	};
+	fs.writeFileSync(path, `${JSON.stringify(baseline, null, "\t")}\n`);
+}
+
+/**
+ * Compare a run against a saved baseline.
+ *
+ * A regression is only reported when the two intervals don't overlap —
+ * i.e. the new run's *upper* bound sits below the baseline's *lower*
+ * bound. Anything less than that is noise, and failing CI on noise
+ * trains people to ignore the gate.
+ *
+ * @param path Path to the baseline JSON.
+ * @param result The current series result.
+ * @returns The process exit code: 1 on a real regression, else 0.
+ */
+function checkBaseline(path: string, result: SelfPlayResult): number {
+	let baseline: Baseline;
+	try {
+		baseline = JSON.parse(fs.readFileSync(path, "utf8"));
+	} catch (err) {
+		console.error(`\nCannot read baseline ${path}: ${(err as Error).message}`);
+		return 1;
+	}
+	const iv = result.interval;
+	console.log(`\nbaseline:  score ${(baseline.score * 100).toFixed(1)}% ` +
+		`(${baseline.elo >= 0 ? "+" : ""}${baseline.elo.toFixed(0)} Elo, ${baseline.games} games, ${baseline.created})`);
+	if (iv.scoreHigh < baseline.scoreLow) {
+		console.error(`REGRESSION: this run's 95% upper bound (${(iv.scoreHigh * 100).toFixed(1)}%) ` +
+			`is below the baseline's lower bound (${(baseline.scoreLow * 100).toFixed(1)}%).`);
+		return 1;
+	}
+	console.log(`no regression detected (intervals overlap).`);
+	return 0;
 }

--- a/sim/tools/strategic-ai/ROADMAP.md
+++ b/sim/tools/strategic-ai/ROADMAP.md
@@ -1,0 +1,205 @@
+# Strategic-AI roadmap
+
+Where the battle AI stands after the difficulty-ladder rework, what to
+do next, and an honest assessment of the "just use a trained model"
+option.
+
+Read `policy/DifficultyPolicy.ts` first — it explains the tier model and
+why the random and light engines were taken off the ladder.
+
+## Where things stand
+
+Measured over 200 mirrored `gen9randombattle` games per tier against the
+`random` engine (see `baselines/README.md` for why that yardstick):
+
+| tier | engine    | score vs random | Elo  | avoidable immune clicks | status-move rate |
+|-----:|:----------|:----------------|:-----|:------------------------|:-----------------|
+| 1    | Heuristic | 61.0%           | +78  | 0 / 5395                | 24.6%            |
+| 2    | Heuristic | 78.0%           | +220 | 0 / 4930                | 21.8%            |
+| 3    | Heuristic | 89.0%           | +363 | 0 / 3972                | 16.3%            |
+| 4    | OnePly    | 91.5%           | +413 | 0 / 3886                | 15.0%            |
+| 5    | MCTS      | 93.5%           | +463 | 0 / 3690                | 15.5%            |
+
+Tiers 3-5 are saturated against random play and separate properly only
+head-to-head. The random yardstick is a drift detector, not a top-end
+ranking — a 2-point gap up here says little about which is stronger.
+
+Tier 5's row is also the least repeatable one: MCTS is wall-clock
+budgeted, so it does a different number of rollouts every run.
+
+For comparison, the two engines that used to hold tiers 1 and 2 sat at
+~3-4% avoidable immune clicks, and the light engine used status moves on
+2.4% of its turns.
+
+## Known gaps, roughly by value
+
+### 1. Tier 5 does not clearly beat tier 4
+
+MCTS wins by ~50 Elo head-to-head, which is a thin margin for something
+running 200ms of rollouts against a 100ms one-ply search. Two likely
+causes worth separating before tuning anything:
+
+- **Rollout policy quality.** Rollouts use `greedyChoiceForSide`, which
+  ranks moves by `BP x STAB x effectiveness` and therefore *never* picks
+  a status move (base power 0). So every rollout plays out as a pure
+  damage race, and the search systematically can't see lines that depend
+  on a support turn.
+- **Fork cost.** `Battle.toJSON`/`fromJSON` per rollout may be eating
+  most of the budget, leaving too few playouts for the tree to mean
+  anything. Instrument playouts-per-decision before assuming the search
+  itself is the problem.
+
+The fork path *is* exercised by self-play (`playGame` defines a `battle`
+getter on the player sub-streams so `ctx.getBattle()` resolves, matching
+what the production host provides). Worth re-checking if a refactor
+touches stream setup: without it, `takeBattleSnapshot` silently returns
+null, `sampleRollout` takes over, and tier 5 quietly degrades to a noisy
+one-ply search while every test still passes.
+
+### 2. Set inference for the foe is a placeholder
+
+`bestAttackingDamage` assumes the foe has a generic 80 BP STAB in each
+of its types. That is deliberately conservative (see the comment about
+why probing all 18 coverage types is worse), but it means the AI is
+blind to the actual metagame: in `gen9randombattle` the generator will
+happily produce a set the AI never considers.
+
+The right fix is to ask the format's own `randomSet` generator what sets
+this species can roll, then maintain a posterior over them narrowed by
+each revealed move and item. That gives calibrated coverage predictions
+instead of either paranoia or blindness, and it is the single largest
+remaining source of misplayed switches.
+
+### 3. Evaluation is hand-tuned constants
+
+`MoveEvaluator` and `SwitchEvaluator` are a few dozen weights picked by
+hand. They are legible and debuggable, which is worth a lot, but they
+are certainly not optimal.
+
+Worth knowing how these are usually wrong, because the two found so far
+were both *structural* rather than mis-tuned: status moves were scored
+without ever multiplying through their accuracy (Hypnosis priced as
+Spore), and sleep was flat-valued at 20 against poison's 16 despite
+removing the target from the game for several turns. Neither shows up as
+a bad constant — they show up as a missing term. Grep for a term the
+damage path applies and the status path doesn't before reaching for a
+tuner.
+
+Two options, in increasing order of effort:
+
+- **Tune the existing weights** against the self-play harness (SPRT
+  gating is already wired up: `--sprt --elo1 10`). Cheap, no new
+  concepts, and probably worth 30-60 Elo.
+- **Learn a value function** from self-play positions and blend it with
+  the heuristic score the way `MctsEngine` already blends rollout
+  reward. Bigger lift, and it needs the position-dumping and training
+  tooling built first.
+
+### 4. Doubles is much weaker than singles
+
+Target selection, spread-move handling, and partner coordination are all
+thinner than the singles path, and none of it is measured — the harness
+only runs singles formats. Anything here should start with a doubles
+self-play ladder, because right now a doubles regression is invisible.
+
+## On using a trained model
+
+The short version: **not worth it for this project, and the reasons are
+about deployment rather than model quality.**
+
+### What exists
+
+The open-source Pokemon-AI work worth knowing about:
+
+- **`metamon`** (Stanford IRIS) — offline RL trained on years of real
+  Showdown replays. The strongest publicly available learned agent, and
+  genuinely good. Python, PyTorch, built around `poke-env`.
+- **`poke-env`** — the standard Python interface for Showdown agents.
+  The substrate most RL work sits on, not an agent itself.
+- **`foul-play`** / **`poke-engine`** — a strong *non*-learned bot: a
+  Rust battle engine plus expectiminimax search with set inference. The
+  closest thing to "what we're building, done well."
+- Assorted PPO/DQN projects. Most are student work that does not beat a
+  decent heuristic; treat published win rates against "random" or
+  "max damage" opponents as meaningless.
+
+### Why it doesn't fit here
+
+The blocker is where our AI has to run. `PlayerAI` executes **inside the
+Minecraft Bedrock Script API sandbox**, in the same script thread as the
+rest of the addon. That environment has no filesystem, no native
+modules, no WASM/ONNX runtime, and a per-tick budget shared with
+everything else the server is doing. A PyTorch policy cannot be shipped
+into it at all.
+
+That leaves two deployment shapes, and both cost more than they return:
+
+**Remote inference over HTTP.** The server-only build could call out to a
+hosted model. But a battle decision sits directly in the player's
+interaction loop, so every turn now carries a network round trip, and
+the failure modes are all bad: a slow response stalls the battle, a
+failed one needs the heuristic engine as a fallback anyway (so we
+maintain both), and the AI becomes unavailable whenever the inference
+host is. We would be adding an operational dependency and a latency
+budget to the most latency-sensitive part of the game, in exchange for
+strength that tier 5 has not yet been shown to need.
+
+**Distil into something shippable.** Train offline, then export a small
+MLP as plain JS weight arrays — no runtime, no network, just arithmetic
+the sandbox can do. This one is actually viable, and it is the honest
+version of "use a trained model" for this codebase. But note what it
+requires: a self-play/replay pipeline, a feature encoder that stays in
+sync between training and inference, and a training loop — none of which
+exist yet. And its natural first use is *gap 3 above*: a learned value
+function blended into the existing search. So the work routes back to
+the same place regardless.
+
+### Recommendation
+
+Do gaps 1-3 first, in order, because they are cheap, measurable with
+tooling that already exists, and each one raises the ceiling for
+anything learned that comes later. In particular, a learned value model
+is only worth training once set inference is real — otherwise it learns
+to evaluate positions described by features that are themselves wrong.
+
+Revisit learned policies if and when tier 5 is clearly at the ceiling of
+what hand-written evaluation plus search can do. It is not close to that
+yet.
+
+## Measuring anything you change
+
+Do not trust a tier-vs-tier winrate from a handful of games. In
+`gen9randombattle`, team quality swings results harder than a couple of
+difficulty tiers, and an unmirrored 40-game series once reported tier 1
+*above* tier 3.
+
+```sh
+# Is this change an improvement at all? (sequential test, stops early)
+node dist/sim/tools/selfplay.js --a 3 --b 3 --games 2000 --mirror --sprt --elo1 10
+
+# Did any tier regress?
+npm run ai:baseline
+
+# Did decision quality regress? (immune clicks, status usage, switch rate)
+node dist/sim/tools/selfplay.js --a 3 --b 3 --games 200 --mirror --telemetry
+```
+
+`--mirror` is not optional. `--engine-b random` is how you tell absolute
+strength from relative strength.
+
+Two traps worth knowing:
+
+- **Tier 5 is not reproducible.** MCTS is wall-clock budgeted, so the
+  same seed gives a different number of rollouts run to run. Measure
+  evaluator changes on tier 3 (deterministic) and use tier 5 only for
+  end-to-end checks.
+- **A rate near its threshold needs a big sample.** ~25 move decisions
+  per game means an 8-game series can't resolve a status-move rate to
+  better than a few points, which is how the tier-5 status assertion
+  managed to both pass and fail on the same code.
+
+To see *why* a move was picked rather than just what, the fastest probe
+is to dump the sorted candidate list from `HeuristicEngine.decideForSlot`
+right after the `scored.sort(...)` call and run 4 games at `--jobs 1`.
+That is how both evaluator gaps above were found: status moves ranked
+first in only ~19% of the decisions where one was legal.

--- a/sim/tools/strategic-ai/baselines/README.md
+++ b/sim/tools/strategic-ai/baselines/README.md
@@ -1,0 +1,51 @@
+# Strategic-AI strength baselines
+
+Each file records one difficulty tier's measured score against the
+`random` engine over 200 mirrored `gen9randombattle` games, seeded
+`11,22,33,44`.
+
+## Why score against `random`?
+
+Tier-vs-tier results only tell you the *ordering*. They can't tell you
+whether a tier got stronger or weaker, because both sides move when you
+retune — the whole ladder can sink while every adjacent comparison still
+looks unchanged. The `random` engine has no knobs, so it can't drift,
+which makes it the only reference that stays comparable across
+revisions.
+
+It does saturate at the top: once a tier is competent it wins ~90% of
+games against random play, so d3/d4/d5 land close together here even
+though they separate cleanly head-to-head. Treat these as a drift
+detector for absolute strength, and use tier-vs-tier runs to compare the
+top tiers with each other.
+
+## Checking for a regression
+
+```sh
+node build
+npm run ai:baseline          # all five tiers
+```
+
+Or one tier:
+
+```sh
+node dist/sim/tools/selfplay.js --a 3 --b 3 --engine-b random \
+  --games 200 --mirror --quiet --seed 11,22,33,44 \
+  --baseline sim/tools/strategic-ai/baselines/d3-vs-random.json
+```
+
+Exit code 1 means this run's 95% upper bound fell below the baseline's
+95% lower bound — i.e. a regression the sample size can actually
+support, not a noise blip. Overlapping intervals pass.
+
+## Refreshing after an intentional change
+
+```sh
+node dist/sim/tools/selfplay.js --a 3 --b 3 --engine-b random \
+  --games 200 --mirror --quiet --seed 11,22,33,44 \
+  --write-baseline sim/tools/strategic-ai/baselines/d3-vs-random.json
+```
+
+Commit the new file with the change that caused it, and say in the
+commit message why the number moved. A baseline refreshed on its own,
+with no explanation, is how a regression gets ratcheted in permanently.

--- a/sim/tools/strategic-ai/baselines/check.sh
+++ b/sim/tools/strategic-ai/baselines/check.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# Score every difficulty tier against the fixed `random` yardstick and
+# fail if any tier regressed past its committed baseline.
+#
+# Assumes `node build` has already run. Takes a few minutes: each tier is
+# 200 mirrored games, which is the sample size the baseline intervals
+# were computed at. Running fewer games widens this run's interval and
+# makes the gate pass on almost anything.
+set -e
+
+dir=$(dirname "$0")
+status=0
+
+for d in 1 2 3 4 5; do
+	printf '\n--- difficulty %s ---\n' "$d"
+	node dist/sim/tools/selfplay.js \
+		--a "$d" --b 3 --engine-b random \
+		--games 200 --mirror --quiet --seed 11,22,33,44 \
+		--baseline "$dir/d$d-vs-random.json" || status=1
+done
+
+exit $status

--- a/sim/tools/strategic-ai/baselines/d1-vs-random.json
+++ b/sim/tools/strategic-ai/baselines/d1-vs-random.json
@@ -1,0 +1,16 @@
+{
+	"format": "gen9randombattle",
+	"mirror": true,
+	"a": {
+		"difficulty": 1
+	},
+	"b": {
+		"difficulty": 3,
+		"engine": "random"
+	},
+	"games": 200,
+	"score": 0.61,
+	"elo": 77.70609119370711,
+	"scoreLow": 0.5438110571045573,
+	"created": "2026-07-26T02:41:11.953Z"
+}

--- a/sim/tools/strategic-ai/baselines/d2-vs-random.json
+++ b/sim/tools/strategic-ai/baselines/d2-vs-random.json
@@ -1,0 +1,16 @@
+{
+	"format": "gen9randombattle",
+	"mirror": true,
+	"a": {
+		"difficulty": 2
+	},
+	"b": {
+		"difficulty": 3,
+		"engine": "random"
+	},
+	"games": 200,
+	"score": 0.78,
+	"elo": 219.86876874730976,
+	"scoreLow": 0.7272897610237888,
+	"created": "2026-07-26T02:41:14.327Z"
+}

--- a/sim/tools/strategic-ai/baselines/d3-vs-random.json
+++ b/sim/tools/strategic-ai/baselines/d3-vs-random.json
@@ -1,0 +1,16 @@
+{
+	"format": "gen9randombattle",
+	"mirror": true,
+	"a": {
+		"difficulty": 3
+	},
+	"b": {
+		"difficulty": 3,
+		"engine": "random"
+	},
+	"games": 200,
+	"score": 0.89,
+	"elo": 363.19892859467495,
+	"scoreLow": 0.846887199866472,
+	"created": "2026-07-26T02:41:16.512Z"
+}

--- a/sim/tools/strategic-ai/baselines/d4-vs-random.json
+++ b/sim/tools/strategic-ai/baselines/d4-vs-random.json
@@ -1,0 +1,16 @@
+{
+	"format": "gen9randombattle",
+	"mirror": true,
+	"a": {
+		"difficulty": 4
+	},
+	"b": {
+		"difficulty": 3,
+		"engine": "random"
+	},
+	"games": 200,
+	"score": 0.915,
+	"elo": 412.80086734086245,
+	"scoreLow": 0.8780025335292736,
+	"created": "2026-07-26T02:41:18.954Z"
+}

--- a/sim/tools/strategic-ai/baselines/d5-vs-random.json
+++ b/sim/tools/strategic-ai/baselines/d5-vs-random.json
@@ -1,0 +1,16 @@
+{
+	"format": "gen9randombattle",
+	"mirror": true,
+	"a": {
+		"difficulty": 5
+	},
+	"b": {
+		"difficulty": 3,
+		"engine": "random"
+	},
+	"games": 200,
+	"score": 0.935,
+	"elo": 463.15930169186527,
+	"scoreLow": 0.8990666666666668,
+	"created": "2026-07-26T03:09:11.971Z"
+}

--- a/sim/tools/strategic-ai/engines/Engine.ts
+++ b/sim/tools/strategic-ai/engines/Engine.ts
@@ -78,6 +78,23 @@ export interface EngineContext {
 	 */
 	ladderAdvanceCap: number;
 	/**
+	 * How sharply the move ladder distinguishes a good option from a
+	 * mediocre one — the exponent applied to the closeness ratio in
+	 * {@link selectByScoreLadder}.
+	 *
+	 * 1 is honest: a candidate scoring half as much as the best is half
+	 * as likely to be reached. Below 1 the curve flattens, so a clearly
+	 * worse option feels nearly as good as the best one and gets picked
+	 * far more often. That is what being bad at Pokemon actually is —
+	 * misjudging *how much* better one line is — and unlike random
+	 * choice it stays bounded by the ladder's sign guard, so no amount
+	 * of flattening reaches a move that accomplishes nothing.
+	 *
+	 * This is the knob that carries most of the strength spread between
+	 * tiers 1-3, which otherwise share an engine. Defaults to 1.
+	 */
+	ladderRatioExponent: number;
+	/**
 	 * Extra matchup-score margin the best bench mon must clear over the
 	 * active mon before a voluntary (non-emergency) switch fires. Lower
 	 * = switch-happier. Scaled per difficulty by `DifficultyPolicy`.
@@ -144,16 +161,27 @@ export interface Engine {
  * @param startIndex Index to start the walk from.
  * @param advanceCap Maximum per-step advance probability in [0, 1].
  * @param prng PRNG used for the advance rolls.
+ * @param ratioExponent Exponent applied to the closeness ratio; below 1
+ * flattens the curve so clearly-worse options are reached more often.
+ * See {@link EngineContext.ladderRatioExponent}. Defaults to 1.
  * @returns The selected candidate. `sorted` must be non-empty.
  */
 export function selectByScoreLadder<T extends { score: number }>(
 	sorted: T[],
 	startIndex: number,
 	advanceCap: number,
-	prng: PRNG
+	prng: PRNG,
+	ratioExponent = 1
 ): T {
 	let idx = Math.max(0, Math.min(startIndex, sorted.length - 1));
 	if (advanceCap <= 0) return sorted[idx];
+	// Nothing good is available (every option is scored negative — an
+	// immune attack, a status move that can't land, a self-KO). There is
+	// no "plausible alternative" to slip to here, only degrees of bad,
+	// so take the least-bad option and skip the walk entirely. Without
+	// this, a heavily flattened ratio curve wanders down the negative
+	// run and surfaces as the AI clicking a move the target is immune to.
+	if (sorted[idx].score <= 0) return sorted[idx];
 	while (idx + 1 < sorted.length) {
 		const cur = sorted[idx].score;
 		const next = sorted[idx + 1].score;
@@ -162,7 +190,8 @@ export function selectByScoreLadder<T extends { score: number }>(
 		// negative same-sign runs because the list is sorted descending.
 		const ratio = cur === next ? 1 : cur > 0 ? next / cur : cur / next;
 		if (!(ratio > 0)) break;
-		if (prng.random() >= Math.min(advanceCap, ratio * advanceCap)) break;
+		const weight = ratioExponent === 1 ? ratio : ratio ** ratioExponent;
+		if (prng.random() >= Math.min(advanceCap, weight * advanceCap)) break;
 		idx++;
 	}
 	return sorted[idx];

--- a/sim/tools/strategic-ai/engines/HeuristicEngine.ts
+++ b/sim/tools/strategic-ai/engines/HeuristicEngine.ts
@@ -34,6 +34,7 @@ import { evaluateMove, type MoveEvalContext } from "../mechanics/MoveEvaluator";
 import { chooseBestSwitch, evaluateMatchup, scaledSpeed } from "../mechanics/SwitchEvaluator";
 import { pickTarget } from "../mechanics/TargetPicker";
 import { chooseTransform } from "../mechanics/TransformPolicy";
+import { hazyView } from "../policy/InfoForgetting";
 import type { BattleStateTracker, TrackedPokemon } from "../state/BattleStateTracker";
 import { selectByScoreLadder, type Engine, type EngineContext } from "./Engine";
 
@@ -305,8 +306,12 @@ export class HeuristicEngine implements Engine {
 		const side = request.side;
 		const sideMon = side.pokemon[slotIndex];
 		const myMon = this.resolveTrackedFromRequest(sideMon, ctx, tracker.mySide);
-		const foeMon = tracker.foeActive;
-		if (!myMon || !foeMon) return "default";
+		const trackedFoe = tracker.foeActive;
+		if (!myMon || !trackedFoe) return "default";
+		// Weak tiers reason from an incomplete picture of the foe rather
+		// than from a corrupted score. Resolved once here so every
+		// decision this slot makes this turn is internally consistent.
+		const foeMon = hazyView(trackedFoe, ctx.infoForgetting, ctx.prng);
 
 		const monId = this.monIdForSlot(side, slotIndex, ctx);
 		const lastMoveId = monId ? ctx.lastMoveByMon.get(monId) : undefined;
@@ -388,7 +393,9 @@ export class HeuristicEngine implements Engine {
 		// 6. Pokerogue-style pick ladder: walk down the sorted list,
 		// advancing with probability proportional to score closeness
 		// (capped per difficulty — difficulty 5 is near-greedy).
-		const chosen = selectByScoreLadder(scored, startIndex, ctx.ladderAdvanceCap, ctx.prng).opt;
+		const chosen = selectByScoreLadder(
+			scored, startIndex, ctx.ladderAdvanceCap, ctx.prng, ctx.ladderRatioExponent
+		).opt;
 		if (monId) ctx.lastMoveByMon.set(monId, chosen.id);
 		ctx.switchCount = Math.max(0, ctx.switchCount - 1);
 		if (chosen.id === "helpinghand") turnPlan.helpingHand = true;
@@ -616,13 +623,10 @@ export class HeuristicEngine implements Engine {
 	): { opt: { id: string, idx: number }, score: number }[] {
 		return moves.map(opt => {
 			const move = moveOf(opt.id);
-			const evalResult = evaluateMove(move, evalCtx);
-			let score = evalResult.score;
-			if (ctx.infoForgetting > 0 && evalCtx.defender.revealedMoves.size > 0 &&
-				ctx.prng.random() < ctx.infoForgetting) {
-				score *= 0.85;
-			}
-			return { opt, score };
+			// Forgetting is applied to the foe *view* in `decideForSlot`,
+			// not to the score: scaling a score down promotes negative
+			// (useless) moves toward zero. See `InfoForgetting`.
+			return { opt, score: evaluateMove(move, evalCtx).score };
 		});
 	}
 

--- a/sim/tools/strategic-ai/engines/LightHeuristicEngine.ts
+++ b/sim/tools/strategic-ai/engines/LightHeuristicEngine.ts
@@ -17,6 +17,8 @@
  * @license MIT
  */
 import { Dex, toID } from "../../../dex";
+import type { Move } from "../../../dex-moves";
+import { abilityBlocksMoveType } from "../mechanics/DamageCalc";
 import type {
 	ChoiceRequest,
 	MoveRequest,
@@ -33,6 +35,8 @@ const SWITCH_OUT_HP = 0.3;
 const SWITCH_OUT_MATCHUP = -3;
 const SWITCH_LOCK_TURNS = 2;
 const PROTECT_CHANCE = 0.15;
+/** Score for a damaging move the target takes no damage from. */
+const NO_EFFECT_SCORE = -60;
 
 const TYPE_MATCHUP_WEIGHT = 2.5;
 const SPEED_TIER_COEFF = 4.0;
@@ -179,8 +183,12 @@ export class LightHeuristicEngine implements Engine {
 				second = m;
 			}
 		}
-		// Avoid repeating the same move when alternatives are close.
-		if (second && best.id === lastMoveId && secondScore >= 0.9 * bestScore) {
+		// Avoid repeating the same move when alternatives are close. Only
+		// meaningful for a positive best score: at 0 or below, `0.9 *
+		// bestScore` is not a "within 10%" test any more, and the swap
+		// would trade a useless move for an equally useless one — which
+		// is how an immune move got picked.
+		if (second && best.id === lastMoveId && bestScore > 0 && secondScore >= 0.9 * bestScore) {
 			best = second;
 		}
 
@@ -254,6 +262,10 @@ export class LightHeuristicEngine implements Engine {
 		if (!foe) return move.basePower || 0;
 		// Simple damage estimate.
 		const dmg = simpleDamage(move, me, foe, ctx.tracker?.field.weather ?? "");
+		// A damaging move that deals nothing (type or ability immunity)
+		// must score below every useful option, not tie with them at 0 —
+		// otherwise the anti-staleness swap below can land on it.
+		if (dmg <= 0) return NO_EFFECT_SCORE;
 		const foeHp = parseCurrentHp(foe.condition);
 		let value = dmg * 0.8;
 		if (dmg >= foeHp) value += 40;
@@ -350,12 +362,22 @@ function scoreStatusMoveLight(
 }
 
 function simpleDamage(
-	move: { basePower: number, category: string, type: string, multihit?: number | number[] },
+	move: {
+		basePower: number,
+		category: string,
+		type: string,
+		multihit?: number | number[],
+		flags?: Move["flags"],
+	},
 	atk: PokemonSwitchRequestData,
 	def: PokemonSwitchRequestData,
 	weather: string
 ): number {
 	if (!move.basePower) return 0;
+	// Ability immunity is invisible to the type chart, so without this a
+	// Ground move scores full damage into a Levitate mon and gets clicked.
+	const defAbility = def.ability || def.baseAbility || "";
+	if (abilityBlocksMoveType(defAbility, move.type, move)) return 0;
 	let bp = move.basePower;
 	if (move.multihit) {
 		if (Array.isArray(move.multihit)) {

--- a/sim/tools/strategic-ai/engines/MctsEngine.ts
+++ b/sim/tools/strategic-ai/engines/MctsEngine.ts
@@ -81,10 +81,39 @@ const ROLLOUT_HALF_WEIGHT_VISITS = 6;
  * variance than pure prior sampling.
  */
 const GREEDY_FOE_REPLY_CHANCE = 0.65;
-/** Fork-eval penalty per non-volatile status on a living mon. */
-const STATUS_EVAL_PENALTY = 0.12;
-/** Fork-eval value per net stat-boost stage on an active mon. */
-const BOOST_EVAL_VALUE = 0.04;
+/**
+ * Fork-eval penalty per non-volatile status on a living mon, in the same
+ * "mons" units as {@link evaluateForkState} (a living mon at full HP is
+ * worth ~1.3).
+ *
+ * Differentiated because a flat penalty made every status equivalent to
+ * ~4% of a Pokemon, so a rollout that landed Spore scored barely above
+ * one that wasted the turn — and with the rollout carrying up to
+ * {@link ROLLOUT_MAX_WEIGHT} of the final score, tier 5 talked itself out
+ * of support moves that tier 4 (no rollouts) played correctly.
+ *
+ * Sleep is by far the largest: the target loses its next 1-3 turns
+ * outright. Freeze would be larger still but is too rare to matter.
+ */
+const STATUS_EVAL_PENALTY: { [status: string]: number } = {
+	slp: 0.5,
+	frz: 0.5,
+	tox: 0.35,
+	par: 0.3,
+	brn: 0.3,
+	psn: 0.22,
+};
+/** Fallback penalty for a status not listed in {@link STATUS_EVAL_PENALTY}. */
+const DEFAULT_STATUS_EVAL_PENALTY = 0.2;
+/**
+ * Fork-eval value per net stat-boost stage on an active mon.
+ *
+ * A single offensive stage is +50% damage output, which cashes out at
+ * roughly a sixth of a Pokemon over the turns a boosted mon survives —
+ * so the old 0.04 undervalued setup by about 3x and rollouts scored a
+ * Swords Dance turn as a straight tempo loss.
+ */
+const BOOST_EVAL_VALUE = 0.13;
 /** Max fork rollouts per arm of a stay-vs-switch comparison. */
 const SWITCH_EVAL_ROLLOUTS = 5;
 /** Fraction of the search budget the switch comparison may consume. */
@@ -197,11 +226,8 @@ export class MctsEngine extends OnePlySearchEngine {
 			const meanReward = n.visits > 0 ? n.totalReward / n.visits : heuristic;
 			const rolloutWeight = ROLLOUT_MAX_WEIGHT *
 				n.visits / (n.visits + ROLLOUT_HALF_WEIGHT_VISITS);
-			let score = (1 - rolloutWeight) * heuristic + rolloutWeight * meanReward;
-			if (ctx.infoForgetting > 0 && evalCtx.defender.revealedMoves.size > 0 &&
-				ctx.prng.random() < ctx.infoForgetting) {
-				score *= 0.85;
-			}
+			// No score-scaling for forgetting; see `InfoForgetting`.
+			const score = (1 - rolloutWeight) * heuristic + rolloutWeight * meanReward;
 			return { opt: { id: n.id, idx: n.idx }, score };
 		});
 	}
@@ -400,7 +426,14 @@ function sampleRollout(
 		reward += 30 * ourCalc.koProbability;
 	} else {
 		// Status move: use the heuristic move-evaluator score as a stand-in.
-		reward += evaluateMove(ourMove, evalCtx).score * 0.3;
+		// Passed through at full weight because both sides of this branch
+		// are already on the same scale — `MoveEvaluator` prices a
+		// damaging move at roughly `100 x` the HP fraction it deals, which
+		// is exactly what the `ourCalc` branch computes. The old 0.3
+		// factor was an unexplained third-of-a-vote that made every
+		// support move look like a wasted turn *only* at tier 5, which is
+		// where players reported the AI "just attacking".
+		reward += evaluateMove(ourMove, evalCtx).score;
 	}
 	if (foeCalc) {
 		const myMaxHp = foeCalc.defenderMaxHp || 1;
@@ -719,7 +752,9 @@ function evaluateForkState(fork: Battle, mySide: Side): number {
 		for (const p of side.pokemon) {
 			const hpFraction = p.maxhp > 0 ? p.hp / p.maxhp : 0;
 			let value = hpFraction + (p.hp > 0 ? 0.3 : 0);
-			if (p.hp > 0 && p.status) value -= STATUS_EVAL_PENALTY;
+			if (p.hp > 0 && p.status) {
+				value -= STATUS_EVAL_PENALTY[p.status] ?? DEFAULT_STATUS_EVAL_PENALTY;
+			}
 			score += sign * value;
 		}
 		const active = side.active[0];

--- a/sim/tools/strategic-ai/engines/OnePlySearchEngine.ts
+++ b/sim/tools/strategic-ai/engines/OnePlySearchEngine.ts
@@ -57,7 +57,7 @@ export class OnePlySearchEngine extends HeuristicEngine {
 			const move = Dex.moves.get(opt.id);
 			if (!move?.exists) return { opt, score: -Infinity };
 			const baseEval = evaluateMove(move, evalCtx);
-			const ourScore = computeOurOutcome(move, evalCtx);
+			const ourScore = computeOurOutcome(move, evalCtx, baseEval.score);
 			let weightedFoe = 0;
 			let totalWeight = 0;
 			for (let i = 0; i < foeMoveCandidates.length; i++) {
@@ -75,11 +75,11 @@ export class OnePlySearchEngine extends HeuristicEngine {
 			// don't go through the calc (status, hazards, pivot) still
 			// score correctly.
 			const search = ourScore.utility - weightedFoe;
-			let score = 0.4 * baseEval.score + search;
-			if (ctx.infoForgetting > 0 && evalCtx.defender.revealedMoves.size > 0 &&
-				ctx.prng.random() < ctx.infoForgetting) {
-				score *= 0.85;
-			}
+			// No score-scaling for forgetting: `evalCtx.defender` is
+			// already the hazy view resolved once per decision, and
+			// scaling a negative score promotes useless moves. See
+			// `InfoForgetting`.
+			const score = 0.4 * baseEval.score + search;
 			return { opt, score };
 		});
 	}
@@ -97,13 +97,27 @@ function topMoveWeights(inference: NonNullable<ReturnType<typeof inferFoeActive>
  * Compute our move's outcome (damage we deal, KO probability, utility
  * contribution). Returns the components so the foe's reply can read
  * `ourKills` to know if we KOed first.
+ *
+ * @param move The move being evaluated.
+ * @param ctx The evaluation context.
+ * @param heuristicScore The heuristic engine's score for `move`, used
+ * as the search-layer utility for non-damaging moves.
+ * @returns The move's search utility plus the KO probability and damage
+ * fraction the foe-reply term needs.
  */
 function computeOurOutcome(
 	move: Move,
-	ctx: MoveEvalContext
+	ctx: MoveEvalContext,
+	heuristicScore: number
 ): { utility: number, koProb: number, ourDamageFraction: number } {
 	if (move.category === "Status") {
-		return { utility: 0, koProb: 0, ourDamageFraction: 0 };
+		// A status move deals no damage, but "no damage" is not "no
+		// value" — setup, hazards, recovery, and status infliction are
+		// exactly how a good player converts a neutral matchup. Scoring
+		// them 0 here while attacks receive their full damage utility
+		// meant the search layer systematically buried every support
+		// move, and the AI only ever attacked.
+		return { utility: heuristicScore, koProb: 0, ourDamageFraction: 0 };
 	}
 	const calc = calculateDamage({
 		attacker: fromTracked(ctx.attacker),

--- a/sim/tools/strategic-ai/mechanics/DamageCalc.ts
+++ b/sim/tools/strategic-ai/mechanics/DamageCalc.ts
@@ -501,10 +501,28 @@ function resolveMoveType(move: Move, input: DamageCalcInput): string {
 	return type;
 }
 
-function abilityImmunityBlocks(moveType: string, move: Move, input: DamageCalcInput): boolean {
-	const ability = toID(input.defender.ability);
-	if (move.category === "Status") return false;
-	switch (ability) {
+/**
+ * Whether the defender's ability blocks a damaging move outright.
+ *
+ * Split out from {@link abilityImmunityBlocks} so the cheaper engines
+ * (which work off raw request data rather than a `CalcPokemon`) share
+ * one table instead of keeping a second, always-staler copy. Wonder
+ * Guard is deliberately excluded: it depends on type effectiveness, so
+ * it belongs with the caller that has the full defender.
+ *
+ * @param ability The defender's ability (any casing; id-ified here).
+ * @param moveType The move's type after any -ate ability conversion.
+ * @param move The move, for its `wind` / `bullet` / `sound` flags.
+ * @param gravity Whether Gravity is active (which grounds Levitate).
+ * @returns true if the move deals no damage to this defender.
+ */
+export function abilityBlocksMoveType(
+	ability: string,
+	moveType: string,
+	move: { flags?: Move["flags"] },
+	gravity = false
+): boolean {
+	switch (toID(ability)) {
 	case "voltabsorb":
 	case "lightningrod":
 	case "motordrive":
@@ -514,14 +532,32 @@ function abilityImmunityBlocks(moveType: string, move: Move, input: DamageCalcIn
 	case "dryskin":
 		return moveType === "Water";
 	case "flashfire":
+	case "wellbakedbody":
 		return moveType === "Fire";
 	case "sapsipper":
 		return moveType === "Grass";
 	case "levitate":
-		return moveType === "Ground" && !input.field.gravity;
-	case "wonderguard":
-		return typeEffectivenessExp(moveType, input.defender) <= 0;
+		return moveType === "Ground" && !gravity;
+	case "eartheater":
+		return moveType === "Ground";
+	// Flag-based blocks: these ignore the move's type entirely, so a
+	// type-chart-only check can never catch them.
+	case "windrider":
+		return !!move.flags?.wind;
+	case "bulletproof":
+		return !!move.flags?.bullet;
+	case "soundproof":
+		return !!move.flags?.sound;
 	}
+	return false;
+}
+
+function abilityImmunityBlocks(moveType: string, move: Move, input: DamageCalcInput): boolean {
+	const ability = toID(input.defender.ability);
+	if (move.category === "Status") return false;
+	if (abilityBlocksMoveType(ability, moveType, move, input.field.gravity)) return true;
+	// Effectiveness-dependent, so it needs the full defender.
+	if (ability === "wonderguard") return typeEffectivenessExp(moveType, input.defender) <= 0;
 	return false;
 }
 

--- a/sim/tools/strategic-ai/mechanics/MoveEvaluator.ts
+++ b/sim/tools/strategic-ai/mechanics/MoveEvaluator.ts
@@ -29,6 +29,51 @@ import {
 } from "./DamageCalc";
 
 /**
+ * Score for a move whose target is immune to it.
+ *
+ * Strongly negative rather than 0 so it always loses to a real option,
+ * and so a same-sign score ladder (see `selectByScoreLadder`) can never
+ * walk from a positive move into an immune one. Still finite, so a mon
+ * left with nothing but immune moves picks one and moves on instead of
+ * falling through to `"default"`.
+ */
+const IMMUNE_MOVE_SCORE = -60;
+
+/**
+ * Most turns of future payoff a setup move is allowed to bank on.
+ *
+ * Without a cap, a boost against a foe that barely scratches us projects
+ * an unbounded number of attacking turns and the AI would set up
+ * forever. Four is about as far ahead as the "nothing changes" premise
+ * holds — past that the foe has switched or found an answer.
+ */
+const SETUP_TURN_CAP = 4;
+
+/**
+ * Haircut applied to projected setup payoff.
+ *
+ * The projection assumes the matchup stays put; in practice the foe
+ * switches, we get statused or flinched, or they simply KO us a turn
+ * earlier than the average roll suggested. Half credit keeps setup
+ * competitive with attacking without making it the default.
+ */
+const SETUP_DISCOUNT = 0.5;
+
+/**
+ * Utility of putting a healthy foe to sleep, before the accuracy
+ * discount in {@link applyStatusAccuracy} and the bulk scaling in
+ * {@link scoreStatusInfliction}.
+ *
+ * Sized against the damage path, which scores roughly `100 x` the HP
+ * fraction dealt: sleep is worth about as much as a strong neutral hit
+ * because the free turns it buys convert into exactly that. Spore ends
+ * up around 30 (100% accurate), Hypnosis around 18 (60%) — so the AI
+ * reaches for the reliable one and still prefers a clean KO over
+ * either.
+ */
+const SLEEP_BASE_VALUE = 34;
+
+/**
  * What a single move evaluation needs to know about the world. Designed
  * to be cheap to fill in from a `BattleStateTracker` plus a
  * `MoveRequest` slot.
@@ -105,7 +150,13 @@ export function evaluateMove(
 		if (evaluation) return evaluation;
 	}
 	if (m.category === "Status") {
-		return evaluateStatus(m, moveId, ctx);
+		// A status move the target simply cannot be affected by is the
+		// same class of mistake as clicking a move it's immune to, and
+		// players read it the same way. Reject it before the per-effect
+		// scoring can hand out any bonuses.
+		const blocked = statusMoveBlockedBy(m, moveId, ctx);
+		if (blocked) return { moveId, score: IMMUNE_MOVE_SCORE, rationale: `blocked:${blocked}` };
+		return applyStatusAccuracy(m, evaluateStatus(m, moveId, ctx), ctx);
 	}
 	const { tracker, attacker, defender } = ctx;
 	const calc = calculateDamage({
@@ -127,6 +178,15 @@ export function evaluateMove(
 		// committed to attacking this turn".
 		defenderTookDamageThisTurn: ctx.defenderTookDamageThisTurn ?? false,
 	});
+	// A move the target is immune to accomplishes literally nothing: it
+	// wastes the turn, reveals the move, and leaves us to eat the reply.
+	// Reject it outright rather than letting the additive bonuses below
+	// (priority, pivot, hazard removal) lift it back above 0 — that is
+	// how a Ground move ends up clicked into a Levitate mon, or Sucker
+	// Punch into a Ghost, until the user faints.
+	if (calc.immune) {
+		return { moveId, score: IMMUNE_MOVE_SCORE, damage: calc, rationale: "immune" };
+	}
 	const maxHp = calc.defenderMaxHp || estimateMaxHp(fromTracked(defender));
 	const damageScore = (calc.avgDamage / Math.max(1, maxHp)) * 100; // 0..100ish
 	let score = damageScore * calc.hitChance;
@@ -225,6 +285,159 @@ export function evaluateMove(
 		}
 	}
 	return { moveId, score, damage: calc, rationale };
+}
+
+/** `Move.target` values that aim at an opposing Pokemon. */
+const FOE_TARGETS = new Set([
+	"normal", "any", "randomNormal", "adjacentFoe",
+	"allAdjacentFoes", "allAdjacent", "scripted",
+]);
+
+/**
+ * Discount a status move's utility by the chance it actually connects.
+ *
+ * The damage path multiplies through `calc.hitChance`, but every branch
+ * of {@link evaluateStatus} returned a raw utility, so Hypnosis (60%)
+ * and Sing (55%) were priced identically to Spore (100%) and Thunder
+ * Wave to Zap Cannon. Clicking a coin-flip status where a reliable one
+ * (or an attack) was available is one of the "ineffective move" cases
+ * players notice.
+ *
+ * Self-, ally- and side-targeting moves (setup, recovery, hazards,
+ * screens) have `accuracy: true` and are untouched.
+ *
+ * Only positive scores are scaled. Shrinking a negative score toward
+ * zero would *promote* a bad move as its accuracy drops — the same
+ * inversion bug that the old score-scaling info-forgetting had.
+ *
+ * @param move The status move being considered.
+ * @param evaluation The raw evaluation from {@link evaluateStatus}.
+ * @param ctx The move evaluation context.
+ * @returns The evaluation with `score` discounted by hit chance.
+ */
+function applyStatusAccuracy(
+	move: Move,
+	evaluation: MoveEvaluation,
+	ctx: MoveEvalContext
+): MoveEvaluation {
+	if (evaluation.score <= 0) return evaluation;
+	if (move.accuracy === true) return evaluation;
+	let accuracy = move.accuracy / 100;
+	// No Guard on either side, and Gravity, make the move land anyway.
+	const noGuard = toID(ctx.attacker.ability) === "noguard" ||
+		toID(ctx.defender.ability) === "noguard";
+	if (noGuard) accuracy = 1;
+	else if (ctx.tracker.field.gravity) accuracy = Math.min(1, accuracy * (1 / 0.6));
+	if (accuracy >= 1) return evaluation;
+	return { ...evaluation, score: evaluation.score * accuracy };
+}
+
+/** Types that are flatly immune to a given non-volatile status. */
+const STATUS_IMMUNE_TYPES: { [status: string]: string[] } = {
+	psn: ["Steel", "Poison"],
+	tox: ["Steel", "Poison"],
+	brn: ["Fire"],
+	par: ["Electric"],
+};
+
+/** Per-status ability immunities, keyed by status id. */
+const STATUS_IMMUNE_ABILITIES: { [status: string]: Set<string> } = {
+	psn: new Set(["immunity", "pastelveil"]),
+	tox: new Set(["immunity", "pastelveil"]),
+	brn: new Set(["waterveil", "waterbubble", "thermalexchange"]),
+	par: new Set(["limber"]),
+	slp: new Set(["insomnia", "vitalspirit", "sweetveil"]),
+	frz: new Set(["magmaarmor"]),
+};
+
+/** Abilities that shrug off every non-volatile status. */
+const ALL_STATUS_IMMUNE_ABILITIES = new Set(["comatose", "purifyingsalt", "shieldsdown"]);
+
+/**
+ * Reasons a status move aimed at the foe will do literally nothing.
+ *
+ * The damage path already refuses type- and ability-immune attacks, but
+ * status moves bypass it entirely, so nothing stopped the AI from
+ * clicking Toxic into a Substitute, Will-O-Wisp into Water Veil, or
+ * anything at all into Gholdengo. To a player those are the same
+ * mistake as an immune attack.
+ *
+ * Self-, ally-, and side-targeting moves are never blocked here — they
+ * don't interact with the foe at all.
+ *
+ * @param move The status move being considered.
+ * @param moveId The move's id.
+ * @param ctx The move evaluation context.
+ * @returns A short reason tag when the move cannot affect the target, or
+ * `null` when it can (or when we can't prove otherwise).
+ */
+function statusMoveBlockedBy(
+	move: Move,
+	moveId: string,
+	ctx: MoveEvalContext
+): string | null {
+	if (!FOE_TARGETS.has(move.target)) return null;
+	const { defender, attacker, tracker } = ctx;
+	const foeAbility = toID(defender.ability || "");
+	const foeItem = toID(defender.item || "");
+	// Infiltrator sees through the foe's Substitute and Safeguard, so
+	// every "we're walled by a barrier" check below has to respect it.
+	const infiltrator = toID(attacker.ability || "") === "infiltrator";
+
+	// Good as Gold: no status move from an opponent ever connects.
+	if (foeAbility === "goodasgold") return "goodasgold";
+	// Magic Bounce returns the move at us, which is worse than passing.
+	if (foeAbility === "magicbounce" && move.flags?.reflectable) return "magicbounce";
+	// Powder moves miss Grass types, Overcoat, and Safety Goggles.
+	if (move.flags?.powder) {
+		if (defender.types.includes("Grass")) return "powderGrass";
+		if (foeAbility === "overcoat") return "overcoat";
+		if (foeItem === "safetygoggles") return "safetygoggles";
+	}
+	// Substitute eats anything that doesn't explicitly punch through it.
+	if (
+		defender.volatiles.has("substitute") && !infiltrator &&
+		!move.flags?.bypasssub && !move.flags?.sound
+	) {
+		return "substitute";
+	}
+	// Type immunity, but only for the handful of status moves that opt
+	// into the type chart (`ignoreImmunity: false`, e.g. Thunder Wave).
+	// The rest deliberately ignore it.
+	if (move.ignoreImmunity === false && !Dex.getImmunity(move.type, defender.types)) {
+		return "typeImmune";
+	}
+	// Leech Seed's Grass immunity is a bespoke `onTryImmunity`, not a
+	// flag or a type-chart entry, so it needs naming.
+	if (moveId === "leechseed" && defender.types.includes("Grass")) return "leechGrass";
+	if (moveId === "leechseed" && defender.volatiles.has("leechseed")) return "seeded";
+
+	// Everything past here is specific to inflicting a status.
+	const status = move.status;
+	if (!status) return null;
+	if (defender.status) return "alreadyStatused";
+	if (ALL_STATUS_IMMUNE_ABILITIES.has(foeAbility)) return foeAbility;
+	if (STATUS_IMMUNE_ABILITIES[status]?.has(foeAbility)) return foeAbility;
+	// Leaf Guard is sun-conditional; Flower Veil covers the whole side
+	// but we only model the active target.
+	const sun = tracker.field.weather === "sunnyday" || tracker.field.weather === "desolateland";
+	if (foeAbility === "leafguard" && sun) return "leafguard";
+	if (foeAbility === "flowerveil" && defender.types.includes("Grass")) return "flowerveil";
+	// Safeguard blocks status infliction (but not stat drops), which is
+	// why this check sits below the general-purpose ones.
+	if (tracker.sides[ctx.foeSide].safeguardTurns > 0 && !infiltrator) return "safeguard";
+	if (STATUS_IMMUNE_TYPES[status]?.some(t => defender.types.includes(t))) return "typeStatus";
+	// Terrain: Misty blocks every major status, Electric blocks sleep —
+	// both only on a grounded target, so an airborne foe is still fair
+	// game.
+	if (tracker.isPokemonGrounded(defender)) {
+		const terrain = tracker.field.terrain;
+		if (terrain === "mistyterrain") return "mistyterrain";
+		if (terrain === "electricterrain" && (status === "slp" || moveId === "yawn")) {
+			return "electricterrain";
+		}
+	}
+	return null;
 }
 
 /**
@@ -517,16 +730,28 @@ function scoreBoostMove(
 	let score = 0;
 	let anyMeaningful = false;
 	let boostsSpeed = false;
-	for (const [stat, amount] of Object.entries(boosts)) {
-		if (typeof amount !== "number") continue;
-		const cur = myBoosts[stat] || 0;
-		// Diminishing returns: +1 from 0 is more valuable than +1 from +5.
-		const incremental = amount > 0 ? Math.max(0, 6 - cur) / 6 : 1;
-		const stageValue = stat === "spe" ? 12 : (stat === "atk" || stat === "spa" ? 9 : 6);
-		const contribution = amount * stageValue * incremental;
-		score += contribution;
-		if (contribution >= 4) anyMeaningful = true;
-		if (stat === "spe" && amount > 0 && cur < 6) boostsSpeed = true;
+	// Preferred model: price the boost as the extra damage it buys over
+	// the turns we expect to survive. See `projectedSetupValue`.
+	const projected = projectedSetupValue(boosts, ctx);
+	if (projected !== null) {
+		score = projected.value;
+		anyMeaningful = projected.meaningful;
+		boostsSpeed = projected.boostsSpeed;
+	} else {
+		// Fallback for when we can't price it — no damaging move known
+		// for the attacker yet (early in a battle, or a synthetic test
+		// context). Flat per-stage values, with diminishing returns.
+		for (const [stat, amount] of Object.entries(boosts)) {
+			if (typeof amount !== "number") continue;
+			const cur = myBoosts[stat] || 0;
+			// Diminishing returns: +1 from 0 is more valuable than +1 from +5.
+			const incremental = amount > 0 ? Math.max(0, 6 - cur) / 6 : 1;
+			const stageValue = stat === "spe" ? 12 : (stat === "atk" || stat === "spa" ? 9 : 6);
+			const contribution = amount * stageValue * incremental;
+			score += contribution;
+			if (contribution >= 4) anyMeaningful = true;
+			if (stat === "spe" && amount > 0 && cur < 6) boostsSpeed = true;
+		}
 	}
 	if (moveId === "bellydrum") {
 		score = (ctx.attacker.hpFraction ?? 1) >= 0.55 ? 60 : -20;
@@ -558,6 +783,180 @@ function scoreBoostMove(
 		if (boostsSpeed && !ctx.weOutspeed) score += 10;
 	}
 	return score;
+}
+
+/**
+ * Fraction of the foe's max HP our best known damaging move deals, and
+ * the fraction of ours the foe's best known reply deals. Cached per
+ * evaluation context because a mon evaluates several moves per turn
+ * against the same pair.
+ */
+const offenseCache = new WeakMap<MoveEvalContext, { ours: number, theirs: number } | null>();
+
+/**
+ * Stat multiplier for a boost stage, as the simulator applies it.
+ *
+ * @param stage The boost stage, clamped to [-6, 6].
+ * @returns The multiplicative modifier.
+ */
+function boostMultiplier(stage: number): number {
+	const s = Math.max(-6, Math.min(6, stage));
+	return s >= 0 ? (2 + s) / 2 : 2 / (2 - s);
+}
+
+/**
+ * Best expected damage either side can deal right now, as a fraction of
+ * the target's max HP.
+ *
+ * Only moves we've actually seen count. For our own side that's the
+ * whole moveset (the request seeds it), so this is exact; for the foe it
+ * grows as the battle reveals moves, which is the correct amount of
+ * information to plan with.
+ *
+ * @param ctx The evaluation context.
+ * @returns Both damage fractions, or `null` if we know no damaging move
+ * for our own attacker and therefore can't price anything.
+ */
+function offenseProfile(ctx: MoveEvalContext): { ours: number, theirs: number } | null {
+	const cached = offenseCache.get(ctx);
+	if (cached !== undefined) return cached;
+	const ours = bestDamageFraction(ctx, ctx.attacker, ctx.defender, ctx.mySide, ctx.foeSide);
+	const result = ours > 0 ?
+		{
+			ours,
+			theirs: bestDamageFraction(ctx, ctx.defender, ctx.attacker, ctx.foeSide, ctx.mySide),
+		} :
+		null;
+	offenseCache.set(ctx, result);
+	return result;
+}
+
+/**
+ * Highest expected damage fraction across a mon's known damaging moves.
+ *
+ * @param ctx The evaluation context (for field and side state).
+ * @param attacker The attacking mon.
+ * @param defender The defending mon.
+ * @param attackerSide The attacker's tracker side id.
+ * @param defenderSide The defender's tracker side id.
+ * @returns The best `avgDamage / maxHp * hitChance`, or 0 if no known
+ * damaging move connects.
+ */
+function bestDamageFraction(
+	ctx: MoveEvalContext,
+	attacker: TrackedPokemon,
+	defender: TrackedPokemon,
+	attackerSide: MoveEvalContext["mySide"],
+	defenderSide: MoveEvalContext["mySide"]
+): number {
+	let best = 0;
+	for (const moveId of attacker.revealedMoves) {
+		const move = Dex.moves.get(moveId);
+		if (!move?.exists || move.category === "Status" || !move.basePower) continue;
+		const calc = calculateDamage({
+			attacker: fromTracked(attacker),
+			defender: fromTracked(defender),
+			move,
+			field: ctx.tracker.field,
+			attackerSide: ctx.tracker.sides[attackerSide],
+			defenderSide: ctx.tracker.sides[defenderSide],
+			isDoubles: ctx.isDoubles,
+		});
+		const maxHp = calc.defenderMaxHp || estimateMaxHp(fromTracked(defender));
+		const frac = (calc.avgDamage / Math.max(1, maxHp)) * calc.hitChance;
+		if (frac > best) best = frac;
+	}
+	return best;
+}
+
+/**
+ * Price a boost move as the extra damage it buys.
+ *
+ * The old model gave every stage a flat constant (+9 for Attack, +12 for
+ * Speed, ...). On the same scale, a neutral STAB hit scores 30-50, so a
+ * Swords Dance could essentially never win — the AI attacked every turn
+ * and looked like it had no idea support moves existed. But the flat
+ * constant is wrong in both directions: the same Swords Dance is worth
+ * almost nothing when we're about to be KOed, and worth the game when
+ * we're walling the foe.
+ *
+ * So price it properly. An offensive boost multiplies our damage output;
+ * a defensive boost buys turns; both cash out as damage dealt over the
+ * turns we expect to live:
+ *
+ *     value = ourDamagePerTurn * (extra damage multiplier) * turnsLeft
+ *
+ * `turnsLeft` comes from how hard the foe actually hits us, and we spend
+ * this turn setting up rather than attacking, so it's one less than the
+ * number of hits we survive. A discount covers what the model ignores
+ * (the foe switching, getting statused, losing the speed tie).
+ *
+ * @param boosts The stat boosts the move applies to the user.
+ * @param ctx The evaluation context.
+ * @returns The projected value plus flags the caller needs, or `null`
+ * when there isn't enough information to price it.
+ */
+function projectedSetupValue(
+	boosts: { [stat: string]: number | undefined },
+	ctx: MoveEvalContext
+): { value: number, meaningful: boolean, boostsSpeed: boolean } | null {
+	const offense = offenseProfile(ctx);
+	if (!offense) return null;
+	const myBoosts = ctx.attacker.boosts;
+	const myHp = ctx.attacker.hpFraction ?? 1;
+	// Floor the incoming damage: against a foe that can't hurt us the
+	// projection would otherwise run away to infinity, and passive
+	// damage (hazards, weather, poison) is real anyway.
+	const foeDamage = Math.max(0.08, offense.theirs);
+	const hitsSurvived = myHp / foeDamage;
+
+	const physical = (ctx.attacker.stats?.atk ?? 0) >= (ctx.attacker.stats?.spa ?? 0);
+	const offensiveStat = physical ? "atk" : "spa";
+	const defensiveStat = physical ? "def" : "spd";
+
+	let damageMultiplier = 1;
+	let defenceMultiplier = 1;
+	let speedStages = 0;
+	let miscValue = 0;
+	for (const [stat, amount] of Object.entries(boosts)) {
+		if (typeof amount !== "number" || amount === 0) continue;
+		const cur = myBoosts[stat] || 0;
+		const ratio = boostMultiplier(cur + amount) / boostMultiplier(cur);
+		if (stat === offensiveStat) damageMultiplier *= ratio;
+		else if (stat === "atk" || stat === "spa") damageMultiplier *= 1 + ((ratio - 1) * 0.25);
+		else if (stat === defensiveStat) defenceMultiplier *= ratio;
+		else if (stat === "def" || stat === "spd") defenceMultiplier *= 1 + ((ratio - 1) * 0.5);
+		else if (stat === "spe") speedStages += amount;
+		// Accuracy / evasion: small flat credit, they don't fit the model.
+		else miscValue += amount * 3;
+	}
+
+	// Offensive: more damage per turn, for every turn after this one.
+	const attackTurns = Math.max(0, Math.min(SETUP_TURN_CAP, hitsSurvived - 1));
+	const damagePerTurn = offense.ours * 100;
+	let value = damagePerTurn * (damageMultiplier - 1) * attackTurns;
+
+	// Defensive: fewer incoming hits means more turns to attack in.
+	if (defenceMultiplier > 1) {
+		const boostedHitsSurvived = (myHp / (foeDamage / defenceMultiplier)) - 1;
+		const extraTurns = Math.min(SETUP_TURN_CAP, boostedHitsSurvived) - attackTurns;
+		if (extraTurns > 0) value += damagePerTurn * extraTurns;
+	}
+
+	// Speed: worth a turn when it flips the speed tier, and little
+	// otherwise. Flipping it means we attack before taking the hit for
+	// the rest of the matchup, which is roughly one extra attack.
+	if (speedStages > 0 && !ctx.weOutspeed) value += damagePerTurn * 0.8;
+	else if (speedStages > 0) value += damagePerTurn * 0.15 * Math.min(1, speedStages);
+
+	value = (value * SETUP_DISCOUNT) + miscValue;
+	return {
+		value,
+		// "Meaningful" gates the setup-window bonus: a boost we can't
+		// cash in (already maxed, or dying this turn) shouldn't collect it.
+		meaningful: value >= 6,
+		boostsSpeed: speedStages > 0 && (myBoosts.spe || 0) < 6,
+	};
 }
 
 /**
@@ -681,8 +1080,7 @@ function scoreDebuffMove(move: Move, ctx: MoveEvalContext): number {
 }
 
 function scoreStatusInfliction(status: string, ctx: MoveEvalContext): number {
-	const { defender, attacker, tracker } = ctx;
-	if (defender.status) return -10; // Already statused.
+	const { defender, attacker } = ctx;
 	// "Stall combo" detection: status with a follow-up plan (Protect to
 	// burn the timer, Recover/Roost to negate the residual damage
 	// trade, a Defensive boost to outlast). When we have one of those
@@ -705,37 +1103,65 @@ function scoreStatusInfliction(status: string, ctx: MoveEvalContext): number {
 		myMoves.has("cosmicpower") || myMoves.has("acidarmor") ||
 		myMoves.has("calmmind") || myMoves.has("bulkup");
 	const stallComboBonus = (hasProtect ? 4 : 0) + (hasRecovery ? 4 : 0) + (hasDefBoost ? 3 : 0);
-	// Electric/Misty Terrain only block status moves on *grounded*
-	// targets — an airborne / Levitate foe is still a legal target.
-	const grounded = tracker.isPokemonGrounded(defender);
-	const mistyBlocks = grounded && tracker.field.terrain === "mistyterrain";
-	const electricBlocks = grounded && tracker.field.terrain === "electricterrain";
+	// Every "this can't land" case (type, ability, terrain, Safeguard,
+	// Substitute, already-statused) is rejected up-front by
+	// `statusMoveBlockedBy`, so from here it's purely about how much the
+	// status is worth against this target.
 	switch (status) {
 	case "tox":
 	case "psn": {
-		if (defender.types.includes("Steel") || defender.types.includes("Poison")) return -20;
-		// Misty Terrain blocks all major statuses on grounded foes;
-		// don't waste a turn trying.
-		if (mistyBlocks) return -10;
-		return 16 + stallComboBonus;
+		// Poison is a damage-over-time clock: worth much less against a
+		// foe that will faint or force us out long before it ticks.
+		const bulk = defender.hpFraction ?? 1;
+		return 16 * (0.5 + 0.5 * bulk) + stallComboBonus;
 	}
 	case "brn": {
-		if (defender.types.includes("Fire")) return -20;
-		if (mistyBlocks) return -10;
-		return 14 + stallComboBonus;
+		// Burn's halved Attack only matters against a physical threat.
+		const physical = defenderLeansPhysical(defender);
+		return (physical ? 18 : 10) + stallComboBonus;
 	}
 	case "par": {
-		if (defender.types.includes("Electric") || defender.types.includes("Ground")) return -20;
-		if (electricBlocks || mistyBlocks) return -10;
-		return (ctx.weOutspeed ? 6 : 14) + stallComboBonus;
+		// Paralysis is a speed-control tool; near-worthless if we're
+		// already faster, and the full-paralysis chance is a bonus.
+		return (ctx.weOutspeed ? 6 : 16) + stallComboBonus;
 	}
 	case "slp": {
-		if (electricBlocks || mistyBlocks) return -10;
-		return 18 + stallComboBonus;
+		// Sleep is the strongest status in the game: the target loses
+		// 1-3 turns outright, which is strictly better than the chip or
+		// stat cut the others apply. It was priced at 20 — a rounding
+		// error above paralysis — so Spore lost to a middling attack
+		// every time. Worth the most against a healthy foe we can't
+		// simply KO; against something already at low HP the attack is
+		// the better click.
+		const bulk = defender.hpFraction ?? 1;
+		return SLEEP_BASE_VALUE * (0.45 + 0.55 * bulk) + stallComboBonus;
 	}
 	case "frz": return 6; // Rare.
 	}
 	return 4;
+}
+
+/**
+ * Guess whether a Pokemon attacks primarily off its physical side.
+ *
+ * Used to price Burn, whose Attack cut is dead weight against a special
+ * attacker. Prefers revealed moves (what it has actually clicked) and
+ * falls back to comparing its base Attack and Special Attack.
+ *
+ * @param mon The Pokemon to classify.
+ * @returns true when it looks physically oriented.
+ */
+function defenderLeansPhysical(mon: TrackedPokemon): boolean {
+	let physical = 0;
+	let special = 0;
+	for (const id of mon.revealedMoves) {
+		const category = Dex.moves.get(id).category;
+		if (category === "Physical") physical++;
+		else if (category === "Special") special++;
+	}
+	if (physical || special) return physical >= special;
+	const baseStats = Dex.species.get(mon.species).baseStats;
+	return !baseStats || baseStats.atk >= baseStats.spa;
 }
 
 /**

--- a/sim/tools/strategic-ai/mechanics/SwitchEvaluator.ts
+++ b/sim/tools/strategic-ai/mechanics/SwitchEvaluator.ts
@@ -47,27 +47,6 @@ export interface MatchupScore {
 	hazardFraction: number;
 }
 
-const COMMON_COVERAGE_TYPES = [
-	"Normal",
-	"Fire",
-	"Water",
-	"Electric",
-	"Grass",
-	"Ice",
-	"Fighting",
-	"Poison",
-	"Ground",
-	"Flying",
-	"Psychic",
-	"Bug",
-	"Rock",
-	"Ghost",
-	"Dragon",
-	"Dark",
-	"Steel",
-	"Fairy",
-];
-
 /**
  * Evaluate the matchup of our `mon` against the foe's active mon. We
  * assume both are at full health unless `mon.hpFraction` says otherwise.
@@ -535,21 +514,20 @@ function bestAttackingDamage(
 		const m = Dex.moves.get(id);
 		if (m && m.category !== "Status" && m.basePower > 0) moves.push(m);
 	}
-	const hasRevealedDamage = moves.length > 0;
 	// Whether to synthesise STAB / coverage proxies for unrevealed moves.
 	//
 	// For the *foe* (`useKnownOnly === true`) the revealed set is
 	// partial, so proxies are essential — they stop a foe that's only
 	// shown one of its two STABs from looking artificially safe.
 	//
-	// For *our* side (`useKnownOnly === false`) the revealed set is
-	// seeded from the battle request and is therefore the *complete*
-	// moveset. Imagining extra STAB/coverage moves on top would
-	// overestimate our own output and skew matchup/switching decisions,
-	// so we only fall back to proxies when (defensively) we somehow have
-	// no revealed damaging move to work from.
-	const addProxies = useKnownOnly || !hasRevealedDamage;
-	if (addProxies) {
+	// For *our* side (`useKnownOnly === false`) we never fabricate. The
+	// tracker seeds `revealedMoves` for our whole team (not just the
+	// active mon) straight from the battle request, so our movesets are
+	// already complete: an empty damaging set means the mon genuinely
+	// has none, not that we haven't seen it yet. Imagining moves for it
+	// would tell the switch evaluator that a pure support wall is an
+	// offensive threat and invite pivots into it.
+	if (useKnownOnly) {
 		// Skip types already covered by a revealed move to avoid
 		// double-counting (revealed Earthquake + imagined "Proxy
 		// Ground" → over-estimate). Emit BOTH categories per type and
@@ -573,20 +551,21 @@ function bestAttackingDamage(
 				accuracy: 100,
 			});
 		};
+		// STAB only. A Pokemon almost certainly has an attack of its own
+		// type, so assuming one is well-founded. Off-type coverage is
+		// not: since the best of the candidates is what gets used below,
+		// probing every type would amount to assuming the foe holds a
+		// perfect coverage move against whatever we bring in. Every
+		// switch-in then looks doomed, the matchup score for our whole
+		// bench collapses, and the engine pivots on phantom threats —
+		// the "dumb switches" players report. If unrevealed coverage is
+		// ever modelled here it needs a usage-weighted distribution, not
+		// a max over all 18 types.
 		for (const t of attackerMon.types) {
 			if (seenProxyTypes.has(t) || revealedTypes.has(t)) continue;
 			seenProxyTypes.add(t);
 			pushProxy("proxystab", t, "Physical");
 			pushProxy("proxystab", t, "Special");
-		}
-		if (!useKnownOnly) {
-			// Coverage moves: the most-feared off-type move. We probe a
-			// shortlist of common types; the best one wins.
-			for (const t of COMMON_COVERAGE_TYPES) {
-				if (seenProxyTypes.has(t) || revealedTypes.has(t)) continue;
-				pushProxy("proxycov", t, "Physical");
-				pushProxy("proxycov", t, "Special");
-			}
 		}
 	}
 	let best: { avgDamage: number, moveId: string } | null = null;

--- a/sim/tools/strategic-ai/policy/DifficultyPolicy.ts
+++ b/sim/tools/strategic-ai/policy/DifficultyPolicy.ts
@@ -6,21 +6,54 @@
  * info-forgetting, switch margin). Centralising this here lets us tune
  * each tier without touching the engines themselves.
  *
- * Mapping (matches the project plan):
+ * Mapping:
  *
- * | difficulty | engine        | ladder cap | info forgetting | switch margin |
- * |-----------:|:--------------|:-----------|:----------------|:--------------|
- * | 1          | RandomEngine  | 0.50       | 1.0             | 18            |
- * | 2          | LightEngine   | 0.50       | 0.50            | 14            |
- * | 3          | HeuristicE.   | 0.50       | 0.20            | 10            |
- * | 4          | OnePly        | 0.30       | 0.10            | 6             |
- * | 5          | MCTS          | 0.00       | 0.00            | 4             |
+ * | difficulty | engine      | cap  | ratio exp | forgetting | switch margin |
+ * |-----------:|:------------|:-----|:----------|:-----------|:--------------|
+ * | 1          | HeuristicE. | 0.75 | 0.30      | 0.85       | 26            |
+ * | 2          | HeuristicE. | 0.60 | 0.40      | 0.55       | 16            |
+ * | 3          | HeuristicE. | 0.30 | 1.00      | 0.25       | 10            |
+ * | 4          | OnePly      | 0.12 | 1.00      | 0.08       | 6             |
+ * | 5          | MCTS        | 0.00 | 1.00      | 0.00       | 4             |
  *
- * The ladder cap bounds the per-step "slip to the next-best move"
- * probability ({@link selectByScoreLadder}); difficulty 5 is fully
- * greedy (no move-selection noise). The switch margin is how much better a bench mon's
- * matchup must score before a voluntary switch fires (boss tiers
- * switch on smaller edges, pokerogue-style).
+ * Measured against a fixed `random`-engine yardstick (200 mirrored
+ * `gen9randombattle` games each, `--engine-b random`), which is the only
+ * reference that stays comparable while the tiers themselves are being
+ * retuned: d1 +110 Elo, d2 +230, d3 +363, d4 +338, d5 +449. Avoidable
+ * immune-move clicks are 0.0-0.1% at every tier against the yardstick's
+ * own 3-4%.
+ *
+ * ## Why every tier plays the same game
+ *
+ * Difficulty 1 used to run {@link RandomEngine} (uniformly random
+ * choices) and difficulty 2 a separate, simpler {@link
+ * LightHeuristicEngine}. Both are still selectable by name, but neither
+ * is on the auto ladder any more, because "weak" was being implemented
+ * as "structurally broken":
+ *
+ * - The random tier clicked moves the target was immune to ~3% of the
+ *   time and switched on a coin flip.
+ * - The light tier scored matchups off the *type chart alone* (so a mon
+ *   with the right coverage move still read as a bad matchup), switched
+ *   unconditionally below 30% HP with no check that the incoming mon
+ *   survived, and used status moves on 2.4% of its turns against the
+ *   real engine's 18%.
+ *
+ * Since both tiers are what low-level trainers and wild Pokemon roll
+ * into, players met one of these on most early encounters and read the
+ * whole AI as having an on/off switch — competent one battle, clicking
+ * Earthquake into a Levitate mon the next.
+ *
+ * So weakness is now expressed the way a weak *player* is weak:
+ * incomplete recall of what the opponent has shown (`infoForgetting`),
+ * a poor sense of *how much* better the best line is
+ * (`ladderRatioExponent`, which carries most of the tier-1-to-3
+ * spread), a greater chance of taking a plausible-but-worse line
+ * (`ladderAdvanceCap`), reluctance to switch (`switchMargin`), and less
+ * lookahead (engine tier). What no tier does any more is pick a move
+ * that accomplishes nothing: {@link selectByScoreLadder} only ever
+ * walks between same-sign scores, so a positive option is never traded
+ * for an immune or useless one no matter how loose the other knobs get.
  *
  * The `engine` option on `PlayerAIOptions` can force any tier to a
  * specific engine for tooling / testing.
@@ -34,18 +67,21 @@ import { MctsEngine } from "../engines/MctsEngine";
 import { OnePlySearchEngine } from "../engines/OnePlySearchEngine";
 import { RandomEngine } from "../engines/RandomEngine";
 
-/** Engine names accepted by `DifficultyPolicy.create`. */
-export type EngineName =
-	| "auto" |
-	"random" |
-	"light" |
-	"heuristic" |
-	"oneply" |
-	"mcts";
+/**
+ * Engine names accepted by {@link pickEngine}, as a runtime list so CLI
+ * tools can validate a flag against it.
+ */
+export const ENGINE_NAMES = [
+	"auto", "random", "light", "heuristic", "oneply", "mcts",
+] as const;
+
+/** Engine names accepted by {@link pickEngine}. */
+export type EngineName = typeof ENGINE_NAMES[number];
 
 /** Per-tier knobs applied to {@link EngineContext}. */
 export interface DifficultyKnobs {
 	ladderAdvanceCap: number;
+	ladderRatioExponent: number;
 	infoForgetting: number;
 	switchMargin: number;
 	searchBudgetMs?: number;
@@ -55,18 +91,36 @@ export interface DifficultyKnobs {
 export function knobsForDifficulty(difficulty: number): DifficultyKnobs {
 	switch (difficulty) {
 	case 1:
-		return { ladderAdvanceCap: 0.50, infoForgetting: 1.0, switchMargin: 18 };
+		return {
+			ladderAdvanceCap: 0.75, ladderRatioExponent: 0.30,
+			infoForgetting: 0.85, switchMargin: 26,
+		};
 	case 2:
-		return { ladderAdvanceCap: 0.50, infoForgetting: 0.50, switchMargin: 14 };
+		return {
+			ladderAdvanceCap: 0.60, ladderRatioExponent: 0.40,
+			infoForgetting: 0.55, switchMargin: 16,
+		};
 	case 3:
-		return { ladderAdvanceCap: 0.50, infoForgetting: 0.20, switchMargin: 10 };
+		return {
+			ladderAdvanceCap: 0.30, ladderRatioExponent: 1,
+			infoForgetting: 0.25, switchMargin: 10,
+		};
 	case 4:
-		return { ladderAdvanceCap: 0.30, infoForgetting: 0.10, switchMargin: 6, searchBudgetMs: 100 };
+		return {
+			ladderAdvanceCap: 0.12, ladderRatioExponent: 1,
+			infoForgetting: 0.08, switchMargin: 6, searchBudgetMs: 100,
+		};
 	case 5:
 		// Fully greedy: no move-selection noise at max difficulty.
-		return { ladderAdvanceCap: 0, infoForgetting: 0.0, switchMargin: 4, searchBudgetMs: 200 };
+		return {
+			ladderAdvanceCap: 0, ladderRatioExponent: 1,
+			infoForgetting: 0, switchMargin: 4, searchBudgetMs: 200,
+		};
 	default:
-		return { ladderAdvanceCap: 0.50, infoForgetting: 0.20, switchMargin: 10 };
+		return {
+			ladderAdvanceCap: 0.30, ladderRatioExponent: 1,
+			infoForgetting: 0.25, switchMargin: 10,
+		};
 	}
 }
 
@@ -97,9 +151,10 @@ export function pickEngine(
 }
 
 function autoFor(difficulty: number): Exclude<EngineName, "auto"> {
-	if (difficulty <= 1) return "random";
-	if (difficulty === 2) return "light";
-	if (difficulty === 3) return "heuristic";
+	// Tiers 1-3 share the heuristic engine and differ only by knobs; see
+	// the module docs for why the random and light engines are no longer
+	// on the auto ladder.
+	if (difficulty <= 3) return "heuristic";
 	if (difficulty === 4) return "oneply";
 	return "mcts";
 }
@@ -110,6 +165,7 @@ function autoFor(difficulty: number): Exclude<EngineName, "auto"> {
 export function applyKnobs(ctx: EngineContext, difficulty: number): void {
 	const knobs = knobsForDifficulty(difficulty);
 	ctx.ladderAdvanceCap = knobs.ladderAdvanceCap;
+	ctx.ladderRatioExponent = knobs.ladderRatioExponent;
 	ctx.infoForgetting = knobs.infoForgetting;
 	ctx.switchMargin = knobs.switchMargin;
 	// Always assign so a reused EngineContext can't inherit a prior tier's

--- a/sim/tools/strategic-ai/policy/InfoForgetting.ts
+++ b/sim/tools/strategic-ai/policy/InfoForgetting.ts
@@ -1,0 +1,90 @@
+/**
+ * Strategic-AI information forgetting.
+ *
+ * Weak tiers need to play *worse*, not *wrongly*. The cheapest honest
+ * way to do that is to take information away: a beginner forgets that
+ * your Gyarados showed Ice Fang two turns ago and walks its Landorus
+ * straight into it. Every decision it makes is still internally
+ * coherent — it just reasons from a smaller set of facts.
+ *
+ * The previous implementation multiplied a move's score by 0.85 at
+ * random, which modelled nothing and actively misranked: a negative
+ * score (an immune or useless move) gets *closer to zero* when scaled
+ * down, so forgetting could promote a do-nothing move above a working
+ * one. That is precisely the behaviour players complained about.
+ *
+ * What we hide, in order of how quickly a real player loses track:
+ *
+ * 1. The foe's revealed moves — the biggest lever, and the one whose
+ *    absence produces the classic beginner error (staying in on a
+ *    threat you've already been shown).
+ * 2. Its revealed item — forgetting a Choice Scarf or Life Orb.
+ *
+ * Boosts, HP, status, types, and species are never hidden: those are
+ * on screen the whole time, and a player who "forgets" them isn't
+ * weak, they're broken.
+ *
+ * **Ability is never hidden either**, even though a forgetful player
+ * plausibly would. Ability is what decides immunity, so hiding it makes
+ * the AI click Earthquake into a Levitate mon — measurably: an earlier
+ * revision of this module that forgot abilities pushed avoidable
+ * immune-move clicks from 0.0% to 0.6% of all moves at difficulty 3.
+ * "Used a move I was immune to" is the single loudest complaint players
+ * have about this AI, and it reads as a bug rather than as a weak
+ * opponent, so no tier is allowed to generate it.
+ *
+ * @license MIT
+ */
+import type { PRNG } from "../../../prng";
+import type { TrackedPokemon } from "../state/BattleStateTracker";
+
+/**
+ * Relative rate at which each fact is forgotten, as a multiple of the
+ * tier's `infoForgetting` probability. Moves go first and fastest.
+ */
+const FORGET_WEIGHT = {
+	moves: 1.0,
+	item: 0.7,
+} as const;
+
+/**
+ * Produce the view of `foe` that a given tier actually gets to reason
+ * about.
+ *
+ * The result is a shallow copy: callers must treat it as read-only, and
+ * must not write tracker state through it. Returns the original object
+ * when nothing was forgotten so the common (full-information) path
+ * allocates nothing.
+ *
+ * Call this **once per decision**, not once per candidate move — a
+ * player who remembers Ice Fang while picking move 1 and forgets it
+ * while picking move 2 is incoherent, and the resulting per-move noise
+ * is what score jitter already does badly.
+ *
+ * @param foe The tracked foe as the tracker actually knows it.
+ * @param forgetting Tier `infoForgetting` probability in [0, 1].
+ * @param prng PRNG for the forgetting rolls.
+ * @returns Either `foe` unchanged, or a shallow copy with some revealed
+ * information removed.
+ */
+export function hazyView(
+	foe: TrackedPokemon,
+	forgetting: number,
+	prng: PRNG
+): TrackedPokemon {
+	if (forgetting <= 0) return foe;
+	const forgetMoves = foe.revealedMoves.size > 0 &&
+		prng.random() < forgetting * FORGET_WEIGHT.moves;
+	const forgetItem = !!foe.item && prng.random() < forgetting * FORGET_WEIGHT.item;
+	if (!forgetMoves && !forgetItem) return foe;
+	return {
+		...foe,
+		// Partial recall rather than total amnesia: keep each revealed
+		// move with an independent coin flip, so a mid tier typically
+		// remembers the foe's STAB but loses the coverage move.
+		revealedMoves: forgetMoves ?
+			new Set([...foe.revealedMoves].filter(() => prng.random() >= forgetting)) :
+			foe.revealedMoves,
+		item: forgetItem ? "" : foe.item,
+	};
+}

--- a/sim/tools/strategic-ai/telemetry/DecisionStats.ts
+++ b/sim/tools/strategic-ai/telemetry/DecisionStats.ts
@@ -1,0 +1,299 @@
+/**
+ * Per-decision telemetry for the strategic AI.
+ *
+ * Winrate tells you *whether* a change helped; it never tells you what
+ * the AI is actually doing wrong. These counters do, and they exist
+ * specifically because the behaviours players complain about are
+ * directly countable:
+ *
+ *   - "it uses moves the Pokemon is immune to" -> {@link immuneMoves}
+ *   - "it never uses status moves to support itself" -> {@link statusMoves}
+ *   - "it makes dumb switches" -> {@link switches}
+ *   - "the battle stalls out" -> {@link rejections} / {@link defaults}
+ *
+ * An immune-move click is a hard bug, not a tuning question: the AI has
+ * a full damage calculator and a type chart, so the correct count is
+ * exactly zero at every difficulty above random. Tracking it as a
+ * number makes that assertable in a test instead of something a player
+ * has to report.
+ *
+ * Recording is opt-in (`PlayerAIOptions.stats`) and costs one damage
+ * calculation per chosen move, so it stays out of the production
+ * decision path.
+ *
+ * @license MIT
+ */
+import { Dex, toID } from "../../../dex";
+import type { ChoiceRequest, MoveRequest } from "../../../side";
+import { calculateDamage, fromTracked } from "../mechanics/DamageCalc";
+import type { BattleStateTracker } from "../state/BattleStateTracker";
+
+/** A plain snapshot of the counters, safe to structured-clone. */
+export interface DecisionCounters {
+	/** Decisions where the engine returned a non-empty command. */
+	decisions: number;
+	/** Chosen commands that selected a move. */
+	moves: number;
+	/** Chosen moves whose target was immune (0 damage from immunity). */
+	immuneMoves: number;
+	/**
+	 * Immune clicks the AI could have avoided — another legal move on the
+	 * same request would have connected.
+	 *
+	 * This is the number that means something. A raw immune click is
+	 * often forced: Choice-locked into Close Combat when the foe brings
+	 * in a Ghost, or mid-Outrage when they bring in a Fairy. Counting
+	 * those as mistakes hides the real ones, so they're excluded here.
+	 * Anything left is a genuine bug and the target is zero.
+	 */
+	avoidableImmuneMoves: number;
+	/**
+	 * Chosen damaging moves that deal 0 damage for any reason (immunity,
+	 * 0 base power against this target, no viable defensive stat).
+	 */
+	zeroDamageMoves: number;
+	/** Chosen moves resisted by the target (below 1x effectiveness). */
+	resistedMoves: number;
+	/** Chosen moves that were `Status` category. */
+	statusMoves: number;
+	/** Voluntary and forced switches. */
+	switches: number;
+	/** `pass` commands emitted in multi-slot requests. */
+	passes: number;
+	/** `default` commands emitted (engine gave up; sim auto-chooses). */
+	defaults: number;
+	/** Choices the simulator rejected. */
+	rejections: number;
+}
+
+/** Rates derived from {@link DecisionCounters}, for reporting. */
+export interface DecisionRates {
+	/** Immune clicks as a fraction of chosen moves (incl. forced ones). */
+	immuneMoveRate: number;
+	/** Avoidable immune clicks as a fraction of chosen moves. Must be 0. */
+	avoidableImmuneMoveRate: number;
+	/** Zero-damage clicks as a fraction of chosen moves. */
+	zeroDamageMoveRate: number;
+	/** Resisted clicks as a fraction of chosen moves. */
+	resistedMoveRate: number;
+	/** Status moves as a fraction of chosen moves. */
+	statusMoveRate: number;
+	/** Switches as a fraction of all decisions. */
+	switchRate: number;
+	/** Rejections as a fraction of all decisions. */
+	rejectionRate: number;
+}
+
+/** Mutable counter set with recording hooks. */
+export class DecisionStats {
+	private readonly counters: DecisionCounters = emptyCounters();
+
+	/**
+	 * Record one decision.
+	 *
+	 * @param request The request the engine answered.
+	 * @param choice The command string the engine returned.
+	 * @param tracker The AI's battle state tracker, or `null` if the AI
+	 * hasn't seen a request with a side id yet.
+	 */
+	record(request: ChoiceRequest, choice: string, tracker: BattleStateTracker | null): void {
+		if (!choice) return;
+		this.counters.decisions++;
+		// Doubles/triples answer every slot in one command.
+		const parts = choice.split(",").map(p => p.trim()).filter(Boolean);
+		for (let slot = 0; slot < parts.length; slot++) {
+			this.recordSlot(parts[slot], slot, request, tracker);
+		}
+	}
+
+	/** Record that the simulator rejected our choice. */
+	recordRejection(): void {
+		this.counters.rejections++;
+	}
+
+	/** A copy of the raw counters. */
+	snapshot(): DecisionCounters {
+		return { ...this.counters };
+	}
+
+	/**
+	 * Fold another counter set into this one.
+	 *
+	 * @param other Counters to add (e.g. from a worker thread).
+	 */
+	merge(other: DecisionCounters): void {
+		for (const key of Object.keys(this.counters) as (keyof DecisionCounters)[]) {
+			this.counters[key] += other[key] ?? 0;
+		}
+	}
+
+	/**
+	 * Classify one slot's command and bump the matching counters.
+	 *
+	 * @param part One comma-separated command (`"move 3"`, `"switch 2"`, ...).
+	 * @param slot Which active slot this command answers.
+	 * @param request The request being answered.
+	 * @param tracker The AI's tracker, used for the damage check.
+	 */
+	private recordSlot(
+		part: string,
+		slot: number,
+		request: ChoiceRequest,
+		tracker: BattleStateTracker | null
+	): void {
+		if (part === "pass") {
+			this.counters.passes++;
+			return;
+		}
+		if (part === "default") {
+			this.counters.defaults++;
+			return;
+		}
+		if (part.startsWith("switch")) {
+			this.counters.switches++;
+			return;
+		}
+		if (!part.startsWith("move")) return;
+		this.counters.moves++;
+		const moveId = resolveChosenMoveId(part, slot, request);
+		if (!moveId || !tracker) return;
+		const move = Dex.moves.get(moveId);
+		if (!move?.exists) return;
+		if (move.category === "Status") {
+			this.counters.statusMoves++;
+			return;
+		}
+		const attacker = tracker.myActive;
+		const defender = tracker.foeActive;
+		if (!attacker || !defender) return;
+		const calc = calculateDamage({
+			attacker: fromTracked(attacker),
+			defender: fromTracked(defender),
+			move,
+			field: tracker.field,
+			attackerSide: tracker.sides[tracker.mySide],
+			defenderSide: tracker.sides[tracker.foeSide],
+		});
+		if (calc.immune) {
+			this.counters.immuneMoves++;
+			if (hadConnectingAlternative(request, slot, moveId, tracker)) {
+				this.counters.avoidableImmuneMoves++;
+			}
+		}
+		if (calc.avgDamage <= 0) this.counters.zeroDamageMoves++;
+		else if (Dex.getEffectiveness(move.type, defender.types) < 0) this.counters.resistedMoves++;
+	}
+}
+
+/**
+ * Whether the request offered any other usable move that wasn't blocked
+ * by immunity.
+ *
+ * @param request The request that was answered.
+ * @param slot The active slot the choice was for.
+ * @param chosenId The move id that was chosen.
+ * @param tracker The AI's tracker, for the damage check.
+ * @returns true if a different legal move would have connected, meaning
+ * the immune click was avoidable.
+ */
+function hadConnectingAlternative(
+	request: ChoiceRequest,
+	slot: number,
+	chosenId: string,
+	tracker: BattleStateTracker
+): boolean {
+	const active = (request as MoveRequest).active?.[slot];
+	const attacker = tracker.myActive;
+	const defender = tracker.foeActive;
+	if (!active?.moves || !attacker || !defender) return false;
+	for (const entry of active.moves) {
+		const id = toID(entry.id || entry.move);
+		if (!id || id === chosenId) continue;
+		if (entry.disabled || entry.pp === 0) continue;
+		const alt = Dex.moves.get(id);
+		if (!alt?.exists) continue;
+		// A status move always "connects" in the sense that matters here:
+		// it does something, whereas the immune attack does nothing.
+		if (alt.category === "Status") return true;
+		const calc = calculateDamage({
+			attacker: fromTracked(attacker),
+			defender: fromTracked(defender),
+			move: alt,
+			field: tracker.field,
+			attackerSide: tracker.sides[tracker.mySide],
+			defenderSide: tracker.sides[tracker.foeSide],
+		});
+		if (!calc.immune && calc.avgDamage > 0) return true;
+	}
+	return false;
+}
+
+/**
+ * Zeroed counters.
+ *
+ * @returns A fresh {@link DecisionCounters} with every field at 0.
+ */
+export function emptyCounters(): DecisionCounters {
+	return {
+		decisions: 0,
+		moves: 0,
+		immuneMoves: 0,
+		avoidableImmuneMoves: 0,
+		zeroDamageMoves: 0,
+		resistedMoves: 0,
+		statusMoves: 0,
+		switches: 0,
+		passes: 0,
+		defaults: 0,
+		rejections: 0,
+	};
+}
+
+/**
+ * Derive reportable rates from raw counters.
+ *
+ * @param c The counters to summarise.
+ * @returns Fractions, with 0 substituted for any 0/0 denominator.
+ */
+export function decisionRates(c: DecisionCounters): DecisionRates {
+	const perMove = (n: number) => (c.moves > 0 ? n / c.moves : 0);
+	const perDecision = (n: number) => (c.decisions > 0 ? n / c.decisions : 0);
+	return {
+		immuneMoveRate: perMove(c.immuneMoves),
+		avoidableImmuneMoveRate: perMove(c.avoidableImmuneMoves),
+		zeroDamageMoveRate: perMove(c.zeroDamageMoves),
+		resistedMoveRate: perMove(c.resistedMoves),
+		statusMoveRate: perMove(c.statusMoves),
+		switchRate: perDecision(c.switches),
+		rejectionRate: perDecision(c.rejections),
+	};
+}
+
+/**
+ * Resolve which move a `move N` command selected, using the request's
+ * own move list so the mapping matches whatever the simulator offered.
+ *
+ * @param part The single-slot command (`"move 2 1"`, `"move 3 tera"`, ...).
+ * @param slot Which active slot the command answers.
+ * @param request The request being answered.
+ * @returns The move id, or `null` if the command doesn't name a
+ * resolvable move (e.g. `move <name>` against a request with no
+ * matching entry).
+ */
+function resolveChosenMoveId(part: string, slot: number, request: ChoiceRequest): string | null {
+	const arg = part.slice("move".length).trim().split(/\s+/)[0];
+	if (!arg) return null;
+	const active = (request as MoveRequest).active?.[slot];
+	const moves = active?.moves;
+	const index = Number(arg);
+	if (Number.isInteger(index) && index >= 1) {
+		// `move N` is 1-based over the request's move list.
+		const entry = moves?.[index - 1];
+		return entry ? toID(entry.id || entry.move) : null;
+	}
+	// Engines emit indices, but a hand-written `move <id>` is legal too.
+	const id = toID(arg);
+	if (!moves) return id || null;
+	const entry = moves.find(m => toID(m.id || m.move) === id);
+	return entry ? toID(entry.id || entry.move) : id || null;
+}

--- a/test/sim/misc/teams-pack-roundtrip.js
+++ b/test/sim/misc/teams-pack-roundtrip.js
@@ -1,0 +1,107 @@
+'use strict';
+
+/**
+ * `Teams.pack` and `Teams.unpack` must stay field-for-field symmetric.
+ *
+ * This fork adds four PokeBedrock fields to the packed format (`uuid`,
+ * `currentHealth`, `status`, `movesInfo`). `unpack` read all four while
+ * `pack` wrote none of them, so every field after the species shifted by
+ * four positions on a round trip: `movesInfo` was parsed out of the EV
+ * spread, every move came back on NaN PP, and battles opened with
+ * `|cant|p1a: X|nopp` on all four slots and stalled until the turn cap.
+ *
+ * That failure is invisible in normal play (the client packs teams once
+ * and the server unpacks the same string) and only shows up when
+ * something round-trips a team — which is exactly what the AI self-play
+ * harness does.
+ */
+
+const assert = require('../../assert');
+
+const { Teams } = require('../../../dist/sim/teams');
+
+/** A plain competitive set, as a client would submit it. */
+function vanillaSet() {
+	return {
+		name: 'Pika',
+		species: 'Pikachu',
+		item: 'lightball',
+		ability: 'static',
+		moves: ['thunderbolt', 'voltswitch'],
+		nature: 'Timid',
+		evs: { spa: 252, spe: 252 },
+		ivs: {},
+		level: 100,
+	};
+}
+
+/** The same set carrying mid-battle PokeBedrock state. */
+function pokebedrockSet() {
+	return {
+		...vanillaSet(),
+		uuid: 'abc-123',
+		currentHealth: 87,
+		status: 'par',
+		movesInfo: [{ pp: 12, maxPp: 15 }, { pp: 20, maxPp: 20 }],
+	};
+}
+
+describe('Teams.pack / Teams.unpack round trip', () => {
+	it('preserves the PokeBedrock fields', () => {
+		const set = Teams.unpack(Teams.pack([pokebedrockSet()]))[0];
+		assert.equal(set.uuid, 'abc-123');
+		assert.equal(set.currentHealth, 87);
+		assert.equal(set.status, 'par');
+		assert.deepEqual(set.movesInfo, [{ pp: 12, maxPp: 15 }, { pp: 20, maxPp: 20 }]);
+	});
+
+	it('keeps the standard fields aligned', () => {
+		const set = Teams.unpack(Teams.pack([pokebedrockSet()]))[0];
+		assert.equal(set.species, 'Pikachu');
+		assert.equal(set.ability, 'Static');
+		assert.equal(set.item, 'Light Ball');
+		assert.deepEqual(set.moves, ['Thunderbolt', 'Volt Switch']);
+		assert.equal(set.nature, 'Timid');
+		// Level 100 is the format default and packs as empty, so it comes
+		// back unset; a non-default level is asserted in the team case.
+		assert.equal(set.level, undefined);
+		assert.deepEqual(set.evs, { hp: 0, atk: 0, def: 0, spa: 252, spd: 0, spe: 252 });
+	});
+
+	it('leaves a set without PokeBedrock state clean', () => {
+		// `parseInt('')` is NaN, and a NaN currentHealth is one `??` away
+		// from being applied as real HP (`Pokemon` reads it directly).
+		const set = Teams.unpack(Teams.pack([vanillaSet()]))[0];
+		assert.equal(set.currentHealth, undefined);
+		assert.equal(set.movesInfo, undefined);
+		assert.deepEqual(set.moves, ['Thunderbolt', 'Volt Switch']);
+	});
+
+	it('is stable across repeated round trips', () => {
+		for (const mk of [vanillaSet, pokebedrockSet]) {
+			const once = Teams.pack(Teams.unpack(Teams.pack([mk()])));
+			const twice = Teams.pack(Teams.unpack(once));
+			assert.equal(twice, once);
+		}
+	});
+
+	it('survives a full six-member team', () => {
+		const team = [
+			pokebedrockSet(),
+			{ ...vanillaSet(), name: 'Chomp', species: 'Garchomp', ability: 'roughskin', item: '', moves: ['earthquake'] },
+			{ ...pokebedrockSet(), name: 'Tran', species: 'Heatran', ability: 'flashfire', currentHealth: 0, status: 'fnt' },
+			{ ...vanillaSet(), name: 'Toxa', species: 'Toxapex', ability: 'regenerator', level: 50 },
+			{ ...pokebedrockSet(), name: 'Moss', species: 'Amoonguss', ability: 'regenerator', movesInfo: [{ pp: 1, maxPp: 15 }] },
+			{ ...vanillaSet(), name: 'Skarm', species: 'Skarmory', ability: 'sturdy' },
+		];
+		const back = Teams.unpack(Teams.pack(team));
+		assert.equal(back.length, 6);
+		assert.deepEqual(back.map(s => s.species),
+			['Pikachu', 'Garchomp', 'Heatran', 'Toxapex', 'Amoonguss', 'Skarmory']);
+		// A fainted mon's 0 HP must survive as 0, not fall back to undefined.
+		assert.equal(back[2].currentHealth, 0);
+		assert.equal(back[2].status, 'fnt');
+		assert.equal(back[1].currentHealth, undefined);
+		assert.equal(back[3].level, 50);
+	});
+});

--- a/test/sim/tools/strategic-ai/decision-quality.js
+++ b/test/sim/tools/strategic-ai/decision-quality.js
@@ -1,0 +1,165 @@
+'use strict';
+
+/**
+ * Behavioural guarantees for the strategic AI, asserted over real
+ * self-play games rather than synthetic contexts.
+ *
+ * These exist because the failures players actually report are
+ * behavioural, not numeric: "it uses moves my Pokemon is immune to",
+ * "it never uses status moves", "it makes dumb switches". A unit test on
+ * `evaluateMove` can pass while the assembled engine still does all
+ * three, so these run the whole stack and assert on the observed
+ * decisions.
+ *
+ * The immune-move assertion is a hard zero, not a threshold: the AI has
+ * a damage calculator and the type chart, so a *avoidable* immune click
+ * is always a bug. Clicks that were forced (Choice-locked into Close
+ * Combat when a Ghost switches in, mid-Outrage against a Fairy) are
+ * excluded by `avoidableImmuneMoves` and correctly don't count.
+ */
+
+const assert = require('../../../assert');
+
+const { runSelfPlay } = require('../../../../dist/sim/tools/selfplay');
+const { decisionRates } = require('../../../../dist/sim/tools/strategic-ai/telemetry/DecisionStats');
+
+/** Fixed seed so a failure is reproducible from the mocha output alone. */
+const SEED = '1,2,3,4';
+
+/**
+ * Play a short series and return both contenders' telemetry.
+ *
+ * @param {number} a Contender A's difficulty.
+ * @param {number} b Contender B's difficulty.
+ * @param {number} games Games to play.
+ * @returns {Promise<object>} The self-play result.
+ */
+async function series(a, b, games) {
+	return runSelfPlay({
+		// Small search budgets: these tests assert on decision *quality*,
+		// and a full 200ms MCTS budget per decision would make the suite
+		// take minutes for no extra signal.
+		a: { difficulty: a, searchBudgetMs: 25 },
+		b: { difficulty: b, searchBudgetMs: 25 },
+		games,
+		seed: SEED,
+		telemetry: true,
+		jobs: 0,
+		maxTurns: 200,
+		verbose: false,
+	});
+}
+
+/**
+ * Games per immune-move assertion.
+ *
+ * Sized from measurement, not taste: before the immunity fix, difficulty
+ * 3 produced ~0.27 avoidable immune clicks per game, so 40 games
+ * reliably surfaced ~10. A 6-game series showed zero even with the bug
+ * present, i.e. it asserted nothing.
+ */
+const IMMUNE_SAMPLE_GAMES = 40;
+
+/**
+ * Games per status-move-rate assertion.
+ *
+ * Sized from measurement. A game yields ~22 move decisions, and
+ * difficulty 5 is the noisiest tier by construction (MCTS is wall-clock
+ * budgeted, so the same seed does a different number of rollouts each
+ * run). Measured against difficulty 2: d5 reads 15.1% over 60 games but
+ * swung as low as 9.5% over 24 — i.e. anything under ~60 games is
+ * measuring run-to-run variance, not the policy, and this assertion both
+ * passed and failed on identical code at 24.
+ *
+ * Rates at 60 games, for reference when this moves: d1 30.2%, d3 20.3%,
+ * d4 18.9%, d5 15.1%. The gradient is expected — the weak tiers' pick
+ * ladder wanders off the best move more often, and support moves are
+ * usually the plausible-but-worse option it lands on.
+ */
+const STATUS_SAMPLE_GAMES = 60;
+
+describe('Strategic-AI decision quality (slow)', () => {
+	// Every tier, including 1. The low tiers used to run the random and
+	// light engines, where these two guarantees simply did not hold —
+	// which is exactly why players described the AI as having an on/off
+	// switch. Now that all tiers share a real engine and differ only by
+	// knobs, the guarantees are tier-independent and asserted as such.
+	for (const difficulty of [1, 2, 3, 4, 5]) {
+		it(`difficulty ${difficulty} never clicks an avoidable immune move`, async () => {
+			const result = await series(difficulty, 2, IMMUNE_SAMPLE_GAMES);
+			const counters = result.telemetry.a;
+			assert(counters.moves > 500,
+				`expected a meaningful sample, got ${counters.moves} moves`);
+			assert.equal(counters.avoidableImmuneMoves, 0,
+				`difficulty ${difficulty} clicked ${counters.avoidableImmuneMoves} avoidable ` +
+				`immune move(s) out of ${counters.moves} (seed ${SEED})`);
+		}).timeout(120000);
+
+		it(`difficulty ${difficulty} uses status moves a meaningful fraction of the time`, async () => {
+			const result = await series(difficulty, 2, STATUS_SAMPLE_GAMES);
+			const rates = decisionRates(result.telemetry.a);
+			// Human play on random-battle ladders sits well above 10%:
+			// setup, hazards, recovery and status infliction are how
+			// neutral matchups get converted. A tier that basically never
+			// picks one has the support half of its move pool switched
+			// off — the light engine used to sit at 2.4%.
+			assert(rates.statusMoveRate > 0.10,
+				`difficulty ${difficulty} status-move rate ` +
+				`${(rates.statusMoveRate * 100).toFixed(1)}% is too low — ` +
+				`support moves are being scored out of contention`);
+		}).timeout(120000);
+	}
+
+	it('does not switch on more than half of all decisions', async () => {
+		const result = await series(3, 3, 6);
+		const rates = decisionRates(result.telemetry.a);
+		// Includes forced post-faint switches, so the bar is deliberately
+		// loose; this catches switch-loop regressions, not tuning drift.
+		assert(rates.switchRate < 0.5,
+			`switch rate ${(rates.switchRate * 100).toFixed(1)}% suggests a switch loop`);
+	}).timeout(120000);
+
+	it('the difficulty ladder spans a real strength range', async () => {
+		// Tier-vs-tier scores can't detect the whole ladder sinking, or
+		// every tier collapsing to the same strength, so each tier is
+		// scored against the `random` engine — which has no knobs and so
+		// cannot drift as the tiers themselves are retuned.
+		//
+		// Mirrored games are mandatory here. In `gen9randombattle`, team
+		// quality is a larger effect than a couple of difficulty tiers,
+		// and an unmirrored 40-game series reported d1 at 85% and d3 at
+		// 75% purely on which side drew the better teams.
+		//
+		// What's asserted is only what this sample size can actually
+		// resolve: every tier beats random play, and the bottom and top
+		// of the ladder are far apart. Adjacent tiers are deliberately
+		// close together, so asserting d3 < d4 < d5 here would be
+		// asserting noise — use `selfplay.js --engine-b random` offline
+		// for that.
+		const scores = {};
+		for (const difficulty of [1, 3, 5]) {
+			const result = await runSelfPlay({
+				a: { difficulty, searchBudgetMs: 25 },
+				b: { difficulty: 3, engine: 'random' },
+				games: 60,
+				seed: SEED,
+				mirror: true,
+				jobs: 0,
+				maxTurns: 200,
+				verbose: false,
+			});
+			scores[difficulty] = result.interval.score;
+		}
+		const summary = [1, 3, 5]
+			.map(d => `d${d}=${(scores[d] * 100).toFixed(1)}%`)
+			.join(' ');
+		for (const difficulty of [1, 3, 5]) {
+			assert(scores[difficulty] > 0.5,
+				`difficulty ${difficulty} should beat random play, got ${summary}`);
+		}
+		const span = scores[5] - scores[1];
+		assert(span > 0.1,
+			`difficulty 1 and 5 are only ${(span * 100).toFixed(1)} points apart ` +
+			`(${summary}) — the tiers have collapsed into each other`);
+	}).timeout(300000);
+});

--- a/test/sim/tools/strategic-ai/status-move-blocked.js
+++ b/test/sim/tools/strategic-ai/status-move-blocked.js
@@ -1,0 +1,262 @@
+'use strict';
+
+/**
+ * A status move the target cannot be affected by is the same class of
+ * mistake as clicking a move it's immune to, and players read it the
+ * same way ("it used Toxic into my Substitute and then just stood
+ * there"). The damage path has always refused type- and ability-immune
+ * attacks, but status moves skip that path entirely, so nothing stopped
+ * the evaluator from handing out its normal +16 for Toxic into a Steel
+ * type or Will-O-Wisp into Water Veil.
+ *
+ * Self-play can't cover this: most of these blockers (Good as Gold,
+ * Safeguard, powder into Overcoat) come up a few times in a thousand
+ * games, so a regression would hide for a long time behind an aggregate
+ * rate. Hence direct assertions per blocker.
+ *
+ * The paired "still worth it" cases matter just as much — an
+ * over-eager gate that refuses legal status moves would silently
+ * recreate the "AI never uses status moves" complaint.
+ */
+
+const assert = require('../../../assert');
+
+const { evaluateMove } =
+	require('../../../../dist/sim/tools/strategic-ai/mechanics/MoveEvaluator');
+const { BattleStateTracker } =
+	require('../../../../dist/sim/tools/strategic-ai/state/BattleStateTracker');
+const { Dex } = require('../../../../dist/sim');
+
+function mkTracked(speciesName, opts = {}) {
+	const species = Dex.species.get(speciesName);
+	if (!species.exists) throw new Error(`Unknown species: ${speciesName}`);
+	return {
+		id: `mon:${species.id}`,
+		name: species.name,
+		species: species.id,
+		level: opts.level ?? 100,
+		condition: '100/100',
+		hpFraction: opts.hpFraction ?? 1,
+		status: opts.status ?? '',
+		boosts: opts.boosts ?? {},
+		types: opts.types ?? [...species.types],
+		terastallized: false,
+		ability: opts.ability ?? '',
+		baseAbility: opts.ability ?? '',
+		item: opts.item ?? '',
+		revealedMoves: new Set(opts.revealedMoves || []),
+		sameMoveStreak: 0,
+		choiceLocked: false,
+		lastMoveFailed: false,
+		stats: opts.stats,
+		volatiles: new Set(opts.volatiles || []),
+		fainted: false,
+		active: true,
+		position: 0,
+	};
+}
+
+function ctxFor(attacker, defender, tracker) {
+	return {
+		tracker,
+		attacker,
+		defender,
+		mySide: 'p1',
+		foeSide: 'p2',
+		weOutspeed: true,
+		isDoubles: false,
+		valueOfBestSwitch: 0,
+	};
+}
+
+/**
+ * Score a status move in a fresh battle state.
+ *
+ * @param {string} moveId The status move to evaluate.
+ * @param {object} attacker Tracked attacker, from `mkTracked`.
+ * @param {object} defender Tracked defender, from `mkTracked`.
+ * @param {(tracker: object) => void} [setup] Mutates field/side state.
+ * @returns {object} The `MoveEvaluation`.
+ */
+function score(moveId, attacker, defender, setup) {
+	const tracker = new BattleStateTracker({ mySide: 'p1' });
+	if (setup) setup(tracker);
+	return evaluateMove(Dex.moves.get(moveId), ctxFor(attacker, defender, tracker));
+}
+
+describe('Strategic-AI status-move blocking', () => {
+	const clefable = () => mkTracked('Clefable', { ability: 'magicguard' });
+
+	describe('rejects status moves that cannot possibly land', () => {
+		const cases = [
+			['Toxic into a Steel type', 'toxic', () => mkTracked('Skarmory')],
+			['Toxic into a Poison type', 'toxic', () => mkTracked('Toxapex')],
+			['Will-O-Wisp into a Fire type', 'willowisp', () => mkTracked('Volcarona')],
+			['Will-O-Wisp into Water Veil', 'willowisp',
+				() => mkTracked('Wailord', { ability: 'waterveil' })],
+			['Thunder Wave into a Ground type', 'thunderwave', () => mkTracked('Garchomp')],
+			['Thunder Wave into Limber', 'thunderwave',
+				() => mkTracked('Hitmontop', { ability: 'limber' })],
+			['Spore into Insomnia', 'spore',
+				() => mkTracked('Noctowl', { ability: 'insomnia' })],
+			['Spore into a Grass type (powder)', 'spore', () => mkTracked('Amoonguss')],
+			['Spore into Overcoat (powder)', 'spore',
+				() => mkTracked('Mandibuzz', { ability: 'overcoat' })],
+			['Spore into Safety Goggles (powder)', 'spore',
+				() => mkTracked('Garchomp', { item: 'safetygoggles' })],
+			['Toxic into Good as Gold', 'toxic',
+				() => mkTracked('Gholdengo', { ability: 'goodasgold' })],
+			['Toxic into a Substitute', 'toxic',
+				() => mkTracked('Garchomp', { volatiles: ['substitute'] })],
+			['Toxic into an already-poisoned foe', 'toxic',
+				() => mkTracked('Garchomp', { status: 'psn' })],
+			['Leech Seed into a Grass type', 'leechseed', () => mkTracked('Amoonguss')],
+			['Stun Spore into Purifying Salt', 'stunspore',
+				() => mkTracked('Garganacl', { ability: 'purifyingsalt' })],
+		];
+		for (const [label, moveId, mkFoe] of cases) {
+			it(label, () => {
+				const result = score(moveId, clefable(), mkFoe());
+				assert(result.score < 0,
+					`${label}: expected a negative score, got ${result.score} ` +
+					`(${result.rationale})`);
+			});
+		}
+
+		it('Toxic under the foe\'s Safeguard', () => {
+			const result = score('toxic', clefable(), mkTracked('Garchomp'), tracker => {
+				tracker.sides.p2.safeguardTurns = 5;
+			});
+			assert(result.score < 0,
+				`expected a negative score, got ${result.score} (${result.rationale})`);
+		});
+
+		it('Toxic on a grounded foe in Misty Terrain', () => {
+			const result = score('toxic', clefable(), mkTracked('Garchomp'), tracker => {
+				tracker.field.terrain = 'mistyterrain';
+			});
+			assert(result.score < 0,
+				`expected a negative score, got ${result.score} (${result.rationale})`);
+		});
+	});
+
+	describe('still uses status moves that can land', () => {
+		const cases = [
+			['Toxic into a neutral foe', 'toxic', () => mkTracked('Garchomp')],
+			['Will-O-Wisp into a physical attacker', 'willowisp',
+				() => mkTracked('Garchomp', { revealedMoves: ['earthquake'] })],
+			['Spore into a non-Grass foe', 'spore', () => mkTracked('Garchomp')],
+			// Glare is Normal-type and ignores the type chart, so Ground
+			// types are *not* immune to it — only Thunder Wave's Electric
+			// typing blocks them. A gate that keys off "paralysis" alone
+			// rather than the move would wrongly refuse this.
+			['Glare into a Ground type', 'glare', () => mkTracked('Garchomp')],
+			// Sound moves and `bypasssub` moves punch through Substitute.
+			['Growl through a Substitute', 'growl',
+				() => mkTracked('Garchomp', { volatiles: ['substitute'] })],
+		];
+		for (const [label, moveId, mkFoe] of cases) {
+			it(label, () => {
+				const result = score(moveId, clefable(), mkFoe());
+				assert(result.score > 0,
+					`${label}: expected a positive score, got ${result.score} ` +
+					`(${result.rationale})`);
+			});
+		}
+
+		it('Toxic into an airborne foe under Misty Terrain (terrain only affects grounded)', () => {
+			// Dragonite, not Corviknight: a Steel-type flyer is
+			// poison-immune anyway and would pass for the wrong reason.
+			const result = score('toxic', clefable(), mkTracked('Dragonite'), tracker => {
+				tracker.field.terrain = 'mistyterrain';
+			});
+			assert(result.score > 0,
+				`expected a positive score, got ${result.score} (${result.rationale})`);
+		});
+
+		it('Toxic through Safeguard with Infiltrator', () => {
+			const attacker = mkTracked('Noivern', { ability: 'infiltrator' });
+			const result = score('toxic', attacker, mkTracked('Garchomp'), tracker => {
+				tracker.sides.p2.safeguardTurns = 5;
+			});
+			assert(result.score > 0,
+				`expected a positive score, got ${result.score} (${result.rationale})`);
+		});
+
+		it('self-targeting status moves are never gated by the foe', () => {
+			// Swords Dance doesn't touch the foe, so no foe-side blocker
+			// may apply — not even Good as Gold.
+			const foe = mkTracked('Gholdengo', { ability: 'goodasgold' });
+			const attacker = mkTracked('Garchomp', { revealedMoves: ['earthquake'] });
+			const result = score('swordsdance', attacker, foe);
+			assert(result.score > 0,
+				`expected a positive score, got ${result.score} (${result.rationale})`);
+		});
+	});
+
+	describe('prices status moves by how often they land', () => {
+		// The damage path always multiplied through hit chance, but every
+		// branch of `evaluateStatus` returned a raw utility, so a
+		// coin-flip sleep was worth exactly as much as a guaranteed one.
+		it('prefers Spore over Hypnosis for the same effect', () => {
+			const foe = mkTracked('Garchomp');
+			const spore = score('spore', clefable(), foe);
+			const hypnosis = score('hypnosis', clefable(), foe);
+			assert(spore.score > hypnosis.score,
+				`Spore (100%) should outscore Hypnosis (60%): ` +
+				`${spore.score} vs ${hypnosis.score}`);
+		});
+
+		it('prefers Glare over Thunder Wave for the same paralysis', () => {
+			const foe = mkTracked('Dragonite');
+			const twave = score('thunderwave', clefable(), foe);
+			const glare = score('glare', clefable(), foe);
+			assert(glare.score > twave.score,
+				`Glare (100%) should outscore Thunder Wave (90%): ` +
+				`${glare.score} vs ${twave.score}`);
+		});
+
+		it('does not discount never-miss self-targeting moves', () => {
+			// `accuracy: true` must be left alone rather than divided by
+			// 100 into oblivion.
+			const attacker = mkTracked('Garchomp', { revealedMoves: ['earthquake'] });
+			const result = score('swordsdance', attacker, mkTracked('Skarmory'));
+			assert(result.score > 5,
+				`expected full credit, got ${result.score} (${result.rationale})`);
+		});
+
+		it('No Guard removes the accuracy discount', () => {
+			const foe = mkTracked('Garchomp');
+			const plain = score('hypnosis', clefable(), foe);
+			const noGuard = score('hypnosis', mkTracked('Machamp', { ability: 'noguard' }), foe);
+			assert(noGuard.score > plain.score,
+				`No Guard Hypnosis should beat a 60% one: ` +
+				`${noGuard.score} vs ${plain.score}`);
+		});
+
+		it('values sleep above the chip and stat-cut statuses', () => {
+			// Sleep removes the target from the game for 1-3 turns, which
+			// is strictly better than poison chip or a halved Attack. It
+			// was priced at 20 against poison's 16, so a middling attack
+			// beat Spore every time.
+			const foe = mkTracked('Garchomp', { revealedMoves: ['earthquake'] });
+			const spore = score('spore', clefable(), foe);
+			const toxic = score('toxic', clefable(), foe);
+			const wisp = score('willowisp', clefable(), foe);
+			assert(spore.score > toxic.score && spore.score > wisp.score,
+				`Spore should outrank Toxic and Will-O-Wisp: ` +
+				`${spore.score} vs ${toxic.score} / ${wisp.score}`);
+		});
+
+		it('values sleep less against a nearly-fainted foe', () => {
+			// At 10% HP the attack is the better click; sleeping something
+			// we were going to KO anyway wastes the turn.
+			const healthy = score('spore', clefable(), mkTracked('Garchomp'));
+			const nearlyDead = score('spore', clefable(),
+				mkTracked('Garchomp', { hpFraction: 0.1 }));
+			assert(healthy.score > nearlyDead.score,
+				`sleep should be worth more against a healthy foe: ` +
+				`${healthy.score} vs ${nearlyDead.score}`);
+		});
+	});
+});


### PR DESCRIPTION
Expands the self-play harness with mirrored seeded teams, confidence intervals, SPRT early stopping, optional decision telemetry, JSON output, and baseline regression gating (plus a new `ai:baseline` script and committed tier baselines). Reworks strategic AI tuning and evaluation across heuristic/one-ply/MCTS paths to avoid immune/useless choices, improve status/setup valuation, and apply info-forgetting via foe-state views instead of score scaling. Also fixes team pack/unpack symmetry for PokeBedrock fields (`uuid`, `currentHealth`, `status`, `movesInfo`) and adds targeted tests for round-tripping, status-block handling, and decision-quality guarantees.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added self-play analysis with engine selection, mirrored matches, confidence intervals, Elo estimates, telemetry, and sequential early stopping.
  * Improved AI difficulty tuning, information handling, move evaluation, setup planning, immunity detection, and switching decisions.
  * Added support for preserving Pokémon health, status, identifiers, and move PP in team data.
* **Bug Fixes**
  * Prevented ineffective, blocked, or immune moves from being incorrectly prioritized.
* **Documentation**
  * Added Strategic-AI roadmap and baseline measurement guidance.
* **Tests**
  * Added coverage for team round-tripping, status moves, and decision quality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->